### PR TITLE
end tags like {% endfor %} now should work

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -64,7 +64,7 @@ exports.parse = function (data, tags, autoescape) {
             parts = token.replace(/^\{% *| *%\}$/g, '').split(' ');
             tagname = parts.shift();
 
-            if (tagname === 'end') {
+            if (tagname === 'end' || (index > 0 && ('end' + stack[index - 1][0].name) === tagname)) {
                 if (_.last(stack).name === 'autoescape') {
                     escape = last_escape;
                 }

--- a/tests/parser.test.js
+++ b/tests/parser.test.js
@@ -22,6 +22,12 @@ exports.Tags = testCase({
         test.done();
     },
 
+    'basic tag with named end': function (test) {
+        var output = parser.parse('{% foo %}{% endfoo %}', { foo: { ends: true } });
+        test.deepEqual([{ type: parser.TOKEN_TYPES.LOGIC, name: 'foo', args: [], compile: { ends: true }, tokens: [] }], output, 'end matches start tag');
+        test.done();
+    },
+
     'basic tag with ends': function (test) {
         var output = parser.parse('{% blah %}{% end %}', { blah: { ends: true } });
         test.deepEqual([{ type: parser.TOKEN_TYPES.LOGIC, name: 'blah', args: [], compile: { ends: true }, tokens: [] }], output);


### PR DESCRIPTION
Adding support for tags with named end tags, like {% for %} and {% endfor %}

Not the best solution, as {% end %} still works, but I figure I didn't want to break everything all at once.
