### PR TITLE
added a simple "verbatim" tag

### DIFF
--- a/lib/tags.js
+++ b/lib/tags.js
@@ -350,3 +350,16 @@ exports.filter = function (indent) {
 };
 exports.filter.ends = true;
 
+exports.verbatim = function (indent) {
+    var out = '';
+    _.each(this.tokens, function (token, index) {
+        if (token.name){
+            out += '{{'+token.name+'}}';
+        }else{
+            out += token.replace(/\"/g,'\\"').replace(/\n/g, '"+\n\n"')
+        }
+    })
+    return '\n__output += "'+out+'";\n';
+};
+exports.verbatim.ends = true;
+


### PR DESCRIPTION
allows the rendering of html content with '{{'s and '}}'s that don't get rendered.
to bring this https://gist.github.com/629508 django tag along to node...

useful with http://icanhazjs.com/ templates

enhancement
- I didn't see an obvious way to access {% %} block tags and include them.  

(this is my first pull request, I hope I'm doing it right)
