### PR TITLE
Cleanup of unused variable in tag function output.

### DIFF
--- a/lib/tags.js
+++ b/lib/tags.js
@@ -218,7 +218,7 @@ exports['for'] = function (indent) {
         parser.compile.call(this, indent + '     ');
 
     out = '(function () {\n' +
-        '    var ' + operand1 + ', forloop = {}, __forloopKey, __forloopIndex = 0, __forloopLength = 0,' +
+        '    var forloop = {}, __forloopKey, __forloopIndex = 0, __forloopLength = 0,' +
         '__origOperand1Value = __context["' + operand1 + '"];\n' +
         helpers.setVar('__forloopIter', operand2) +
         '    else {\n' +


### PR DESCRIPTION
small fix to get rid of the non-context operand1 variable prior to fixes involved in #34 and #36
