### PR TITLE
Small fix in index.js to support Windows paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,7 +132,7 @@ exports.compileFile = function (filepath) {
     }
 
     get = function () {
-        var file = ((/^\//).test(filepath)) ? filepath : _config.root + '/' + filepath,
+        var file = ((/^\//).test(filepath) || (/^.:/).test(filepath)) ? filepath : _config.root + '/' + filepath,
             data = fs.readFileSync(file, config.encoding);
         tpl = getTemplate(data, { filename: filepath });
     };


### PR DESCRIPTION
Windows (don't judge me brah!) has a different style root path that was failing index.js

Never done a pull request before. I hope this works! 
