### PR TITLE
Allow valid JS method names for template functions

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -373,7 +373,7 @@ exports.compile = function compile(indent, parentBlock) {
         }
 
         if (token.type === VAR_TOKEN) {
-            name = token.name;//.replace(/\W/g, '_');
+            name = token.name.replace(/[^0-9A-Z_$]/gi, '_');
             key = (helpers.isLiteral(name)) ? '["' + name + '"]' : '.' + name;
             args = (token.args && token.args.length) ? token.args : '';
 


### PR DESCRIPTION
Related to issue #81
