### PR TITLE
Add test for accessing keys containing periods.

### DIFF
--- a/lib/parser.test.js
+++ b/lib/parser.test.js
@@ -270,6 +270,9 @@ exports.Variable = testCase({
         tpl = swig.compile('{{ a[0][h.g.i]["c"].b[d] }}');
         test.strictEqual(tpl({ a: { '0': { q: { c: { b: { foo: 'hi!' }}}}}, h: { g: { i: 'q' } }, d: 'foo' }), 'hi!', 'stupid complex variable notation is stupid');
 
+        tpl = swig.compile('{{ a["b.c"] }}');
+        test.strictEqual(tpl({ a: {"b.c": "hi"} }), 'hi', 'key containing period');
+
         test.done();
     },
 


### PR DESCRIPTION
Keys containing periods should be accessible in templates, such as: {{ foo['bar.baz'] }}

Currently, when trying to do so, the following error occurs:

Uncaught SyntaxError: Unexpected string 
