### PR TITLE
Fix block inheritance

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -353,7 +353,7 @@ exports.compile = function compile(indent, parentBlock, context) {
                         throw new Error('Block "' + blockname + '" found nested in another block tag on line' + token.line + '.');
                     }
                     try {
-                        if (this.hasOwnProperty('parent') && this.parent.blocks.hasOwnProperty(blockname)) {
+                        if (this.hasOwnProperty('parent') && this.parent.blocks && this.parent.blocks.hasOwnProperty(blockname)) {
                             this.blocks[blockname] = compile.call(token, indent + '  ', this.parent.blocks[blockname]);
                         } else if (this.hasOwnProperty('blocks')) {
                             this.blocks[blockname] = compile.call(token, indent + '  ');


### PR DESCRIPTION
Under some conditions, extending layout that defines blocks fails.

This guard condition fixes that. 
