### PR TITLE
Make configuration visible

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,3 +171,6 @@ exports.compile = function (source, options) {
         return tmpl.render(source, options);
     };
 };
+
+exports.config = _config;
+


### PR DESCRIPTION
Introspecting config might be useful for 3rd party apps.

Also, this allows access to filters et al, which is useful for 3rd party tags.
