### PR TITLE
Tell developer which arguments were sent to tag

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -57,7 +57,7 @@ function getTokenArgs(token, parts) {
         }
 
         if (!end.test(out)) {
-            throw new Error('Malformed arguments sent to tag.');
+            throw new Error('Malformed arguments ' + out + ' sent to tag.');
         }
 
         return out.replace(/^ /, '');


### PR DESCRIPTION
On error, report which arguments were sent.

This much improves debugging experience.
