### PR TITLE
Expose filters and helpers

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,3 +171,6 @@ exports.compile = function (source, options) {
         return tmpl.render(source, options);
     };
 };
+
+exports.filters = filters;
+exports.helpers = helpers;


### PR DESCRIPTION
They are useful for reuse for 3rd party tags/filters.
