### PR TITLE
Fix for allowError = false resulting in incorrect error reporting

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ function getTemplate(source, options) {
     return createTemplate(source, key);
 }
 
-exports.compileFile = function (filepath) {
+exports.compileFile = function (filepath, forceAllowErrors) {
     var tpl, get;
 
     if (filepath[0] === '/') {
@@ -151,7 +151,7 @@ exports.compileFile = function (filepath) {
         tpl = getTemplate(data, { filename: filepath });
     };
 
-    if (_config.allowErrors) {
+    if (_config.allowErrors || forceAllowErrors) {
         get();
     } else {
         try {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -364,7 +364,7 @@ function precompile(indent, context) {
                     if (index > 0) {
                         throw new Error('Extends tag must be the first tag in the template, but "extends" found on line ' + token.line + '.');
                     }
-                    token.template = this.compileFile(filepath.replace(/['"]/g, ''));
+                    token.template = this.compileFile(filepath.replace(/['"]/g, ''), true);
                     this.parent = token.template;
 
                     // inherit tokens/blocks from parent.


### PR DESCRIPTION
Added fix for an incorrect error message getting generated when allowError was set to false and the extended file failed compilation.  Errors don't get propagated up to derived files, so the correct error message is not shown.

To reproduce:
-Set allowError to false on the top-level Swig configuration options.  This will exercise the path where compileFile doesn't intercept exceptions.
-Compile a file which calls out a non-existent file (e.g. {% extends "invalid.html" %})
-This will result in an unintended code path getting traversed and the file failure never making it to the error output.

This pull request includes a fix for this case which forces compileFile to carry errors up to the derived file's compilation.  This resolves this issue and will result in the correct error message getting reported.
