### PR TITLE
adding multi-root setting. If param root is an array of strings,

### DIFF
--- a/lib/swig.js
+++ b/lib/swig.js
@@ -142,9 +142,32 @@ exports.compileFile = function (filepath, forceAllowErrors) {
   }
 
   get = function () {
-    var file = ((/^\//).test(filepath) || (/^.:/).test(filepath)) ? filepath : _config.root + '/' + filepath,
-      data = fs.readFileSync(file, config.encoding);
-    tpl = getTemplate(data, { filename: filepath });
+    var excp,
+      getSingle,
+      c;
+    getSingle = function (prefix) {
+      var file = ((/^\//).test(filepath) || (/^.:/).test(filepath)) ? filepath : prefix + '/' + filepath,
+        data;
+      try {
+        data = fs.readFileSync(file, config.encoding);
+        tpl = getTemplate(data, { filename: filepath });
+      } catch (e) {
+        excp = e;
+      }
+    };
+    if (typeof _config.root === "string") {
+      getSingle(_config.root);
+    }
+    if (_config.root instanceof Array) {
+      c = 0;
+      while (tpl === undefined || c < _config.root.length) {
+        getSingle(_config.root[c]);
+        c = c + 1;
+      }
+    }
+    if (tpl === undefined) {
+      throw excp;
+    }
   };
 
   if (_config.allowErrors || forceAllowErrors) {

--- a/tests/node/swig.test.js
+++ b/tests/node/swig.test.js
@@ -59,7 +59,14 @@ describe('swig.compileFile', function () {
       expect(swig.compileFile('included_2.html').render({ array: [1, 1] }))
         .to.equal('2');
     });
-
+    it('accepts an array in root config', function () {
+      swig.init({
+        root: ["/", __dirname + '/templates'],
+        allowErrors: true
+      });
+      expect(swig.compileFile('included_2.html').render({ array: [1, 1] }))
+        .to.equal('2');
+    });
     it('can use an absolute path', function () {
       swig.init({
         root: __dirname + '/templates',


### PR DESCRIPTION
swig will search for the file in directories using the order specified in the array.
