### PR TITLE
Support for modulus operator in swig

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -374,7 +374,7 @@ exports.setVar = function (varName, argument) {
 };
 
 exports.parseIfArgs = function (args, parser) {
-  var operators = ['==', '<', '>', '!=', '<=', '>=', '===', '!==', '&&', '||', 'in', 'and', 'or', 'mod'],
+  var operators = ['==', '<', '>', '!=', '<=', '>=', '===', '!==', '&&', '||', 'in', 'and', 'or', 'mod', '%'],
     errorString = 'Bad if-syntax in `{% if ' + args.join(' ') + ' %}...',
     tokens = [],
     prevType,
@@ -416,8 +416,7 @@ exports.parseIfArgs = function (args, parser) {
       if (prevType === 'operator') {
         throw new Error(errorString);
       }
-      value = value.replace('and', '&&').replace('or', '||');
-      value = value.replace('mod', '%');
+      value = value.replace('and', '&&').replace('or', '||').replace('mod', '%');
       tokens.push({
         value: value
       });

--- a/tests/node/tags/if.test.js
+++ b/tests/node/tags/if.test.js
@@ -43,18 +43,34 @@ describe('Tag: if', function () {
     expect(tpl({ foo: 'b', bar: ['a', 'b', 'c'] })).to.equal('hi!');
   });
 
+  it('can use the "%" operator', function () {
+    var tpl = swig.compile('{% if foo % 2 == 0 %}hi!{% endif %}');
+    expect(tpl({ foo: 4 })).to.equal('hi!');
+
+    tpl = swig.compile('{% if foo % 2 == 0 %}hi!{% endif %}');
+    expect(tpl({ foo: 5 })).to.equal('');
+
+    tpl = swig.compile('{% if foo % 2 %}hi!{% endif %}');
+    expect(tpl({ foo: 4 })).to.equal('');
+
+    tpl = swig.compile('{% if foo % 2 %}hi!{% endif %}');
+    expect(tpl({ foo: 3 })).to.equal('hi!');
+
+  });
+
   it('can use the "mod" operator', function () {
     var tpl = swig.compile('{% if foo mod 2 == 0 %}hi!{% endif %}');
-    expect(tpl({ foo: 4})).to.equal('hi!');
+    expect(tpl({ foo: 4 })).to.equal('hi!');
 
     tpl = swig.compile('{% if foo mod 2 == 0 %}hi!{% endif %}');
-    expect(tpl({ foo: 5})).to.equal('');
+    expect(tpl({ foo: 5 })).to.equal('');
 
     tpl = swig.compile('{% if foo mod 2 %}hi!{% endif %}');
-    expect(tpl({ foo: 4})).to.equal('');
+    expect(tpl({ foo: 4 })).to.equal('');
 
     tpl = swig.compile('{% if foo mod 2 %}hi!{% endif %}');
-    expect(tpl({ foo: 3})).to.equal('hi!');
+    expect(tpl({ foo: 3 })).to.equal('hi!');
+
   });
 
 


### PR DESCRIPTION
If statements will now support either '%' or 'mod'

{% set foo = 4 %}
{% if foo mod 2 == 0 %}hi!{% endif %}

Prints "hi!"

{% set foo = 5 %}
{% if foo mod 2 == 0 %}hi!{% endif %}

Prints nothing
