### PR TITLE
add swig.config function

### DIFF
--- a/lib/swig.js
+++ b/lib/swig.js
@@ -33,6 +33,17 @@ exports.init = function (options) {
   dateformat.defaultTZOffset = _config.tzOffset;
 };
 
+exports.config = function (options) {
+  if (!options) {
+    return _config;
+  }
+  options.filters = options.filters || {};
+  options.tags = options.tags || {};
+  _.extend(options.filters, _config.filters);
+  _.extend(options.tags, _config.tags);
+  _.extend(_config, options);
+};
+
 function TemplateError(error) {
   return { render: function () {
     return '<pre>' + error.stack + '</pre>';

--- a/tests/node/swig.test.js
+++ b/tests/node/swig.test.js
@@ -47,6 +47,37 @@ describe('swig.init', function () {
   });
 });
 
+describe('swig.config', function () {
+  it('can get config information', function () {
+    // rest a value for test
+    expect(swig.config()).to.have.key('tzOffset');
+  });
+
+  it('should update config', function () {
+    swig.init({ allowErrors: true });
+    swig.config({ allowErrors: false });
+    expect(swig.config().allowErrors).not.to.be.ok();
+  });
+
+  it('should not change other config', function () {
+    swig.init({ root: '/data/' });
+    swig.config({ allowErrors: true });
+    expect(swig.config().root).to.equal('/data/');
+  });
+
+  it('should merge filters', function () {
+    swig.init({});
+    swig.config({
+      filters: {
+        min: Math.min
+      }
+    });
+    var filters = swig.config().filters;
+    expect(filters).to.have.key('min');
+    expect(filters).to.have.key('add');
+  });
+});
+
 
 describe('swig.compileFile', function () {
 


### PR DESCRIPTION
1. swig.config()  can get config information for developer debug.
2. swig.config(options) can update some config, not init.
