### PR TITLE
add set method to allow config extension

### DIFF
--- a/lib/swig.js
+++ b/lib/swig.js
@@ -33,6 +33,10 @@ exports.init = function (options) {
   dateformat.defaultTZOffset = _config.tzOffset;
 };
 
+exports.set = function (key, value) {
+  _config[key] = value;
+};
+
 function TemplateError(error) {
   return { render: function () {
     return '<pre>' + error.stack + '</pre>';


### PR DESCRIPTION
The new `set` method allow us to extend configuration (in dev mode for example), here is a use case (using expressJS):

``` js
// in production
// ...
swig.init({
  root: __dirname + '/views'
});
// ...

app.configure('development', function() {
  app.use(express.logger('dev'));
  app.use(express.errorHandler());

  if (true) { // unless this PR is accepted
    swig.init({
      root: __dirname + '/views',
      allowErrors: true,
      cache: false
    });
  } else {
    swig.set('allowErrors', true);
    swig.set('cache', false);
  }
});
```
