### PR TITLE
added {% spaceless %} tag support

### DIFF
--- a/lib/tags.js
+++ b/lib/tags.js
@@ -13,5 +13,6 @@ _.extend(exports, {
   macro: require('./tags/macro'),
   parent: require('./tags/parent'),
   raw: require('./tags/raw'),
-  set: require('./tags/set')
+  set: require('./tags/set'),
+  spaceless: require('./tags/spaceless')
 });

--- a/lib/tags/spaceless.js
+++ b/lib/tags/spaceless.js
@@ -1,0 +1,19 @@
+/**
+ * spaceless
+ */
+module.exports = function (indent, parser) {
+	var output = [],
+		i = this.tokens.length - 1;
+
+	for (i; i >= 0; i -= 1) {
+		this.tokens[i] = this.tokens[i]
+			.replace(/^\s+/gi, "") // trim leading white-space
+			.replace(/>\s+</gi,  "><") // trim white-space between tags
+			.replace(/\s+$/gi, ""); // trim trailing white-space
+	}
+
+	output.push(parser.compile.call(this, indent + '    '));
+	return output.join('');
+};
+
+module.exports.ends = true;

--- a/tests/browser/index.html
+++ b/tests/browser/index.html
@@ -28,6 +28,7 @@
     <script src="parser.test.js"></script>
     <script src="raw.test.js"></script>
     <script src="set.test.js"></script>
+    <script src="spaceless.test.js"></script>
     <script src="swig.test.js"></script>
     <script src="tags.test.js"></script>
 </head>

--- a/tests/node/tags/spaceless.js
+++ b/tests/node/tags/spaceless.js
@@ -1,0 +1,60 @@
+var require = require('../testutils').require,
+  expect = require('expect.js'),
+  swig = require('../../lib/swig');
+
+describe('Tag: spaceless', function () {
+  beforeEach(function () {
+    swig.init({ allowErrors: true });
+  });
+
+  it('removes leading white-space', function () {
+    var spaceless_tmpl = [
+        '{% spaceless %}',
+        ' ',
+        '',
+        '<li>1</li>',
+        '{% endspaceless %}'
+      ].join('\n'),
+
+      tpl = swig.compile(spaceless_tmpl);
+
+    expect(tpl({})).to.equal('<li>1</li>');
+
+  });
+
+  it('removes white-spaces betwen tags', function () {
+    var spaceless_tmpl = [
+        '{% spaceless %}',
+        '<li>1</li>',
+        ' <li>2</li>',
+        '<li>3',
+        '</li>',
+        '<li>4',
+        ' </li>',
+        '<li id="5">',
+        '   </li>',
+
+        '{% endspaceless %}',
+      ].join('\n'),
+
+      tpl = swig.compile(spaceless_tmpl);
+
+    expect(tpl({})).to.equal('<li>1</li><li>2</li><li>3\n</li><li>4\n </li><li id="5"></li>');
+
+  });
+
+  it('removes trailing white-space', function () {
+    var spaceless_tmpl = [
+        '{% spaceless %}',
+        '<li>1</li>',
+        '',
+        '  ',
+        '{% endspaceless %}'
+      ].join('\n'),
+
+      tpl = swig.compile(spaceless_tmpl);
+
+    expect(tpl({})).to.equal('<li>1</li>');
+
+  });
+});


### PR DESCRIPTION
I find the {% spaceless %} tag useful in Django and thought I'd contribute it back as a default tag. 
### Included:
- {% spaceless %} tag added as default tag
- tests for leading, trailing, and "between-tag" whitespace trimming.
### Use:

``` django
{% spaceless %}
    <li>1</li>
  <li>2</li>
        <li>    </li>
<li> 
4
</li>

{% endspaceless %}
```

``` html
<!--// BECOMES //-->
<li>1</li><li>2</li><li></li><li>
4
</li>
<!--// 
    notice it only removes empty whitespace 
    so "4" retains it's original whitespace 
//-->
```
### Notes

I borrowed the "between-tag" whitespace stripping RegEx `>\s+<` directly from the [Django {% spaceless %} function](https://github.com/django/django/blob/master/django/utils/html.py#L135-L138) and added leading and trailing whitespace trimming which doesn't appear to be a function of the Django function (but perhaps should be?)
