### PR TITLE
Make "compile" accessible in templates

### DIFF
--- a/lib/swig.js
+++ b/lib/swig.js
@@ -65,6 +65,8 @@ function createTemplate(data, id) {
   var template = {
       // Allows us to include templates from the compiled code
       compileFile: exports.compileFile,
+      // Allows compiling templates from variables
+      compile: exports.compile,
       // These are the blocks inside the template
       blocks: {},
       // Distinguish from other tokens


### PR DESCRIPTION
Hey. Thanks a lot for swig. I am using it for a project and found the need to render templates stored in context variables. In other words I want to do this in my custom tag:

output += '_output += _this.compile(__tmyVar)(_context);';

I noticed that "compileFile" is available, but not compile, so I added it.
