### PR TITLE
How about this 'iterate' simple iteration tag

### DIFF
--- a/lib/tags.js
+++ b/lib/tags.js
@@ -10,6 +10,7 @@ _.extend(exports, {
   'if': require('./tags/if'),
   'import': require('./tags/import'),
   include: require('./tags/include'),
+  'iterate': require('./tags/iterate'),
   macro: require('./tags/macro'),
   parent: require('./tags/parent'),
   raw: require('./tags/raw'),

--- a/lib/tags/iterate.js
+++ b/lib/tags/iterate.js
@@ -1,0 +1,51 @@
+var helpers = require('../helpers'),
+  _ = require('underscore');
+
+/**
+* iterate
+*/
+module.exports = function (indent, parser) {
+  var thisArgs = _.clone(this.args),
+    operand1 = thisArgs[0],
+    operator = thisArgs[1],
+    operand2 = parser.parseVariable(thisArgs[2]),
+    separator = thisArgs[3],
+    operand3 = parser.parseVariable(thisArgs[4]),
+    output;
+
+  indent = indent || '';
+
+  if (typeof operator !== 'undefined' && operator !== 'with') {
+    throw new Error('Invalid syntax in "iterate" tag');
+  }
+
+  if (typeof separator !== 'undefined' && separator !== 'to') {
+    throw new Error('Invalid syntax in "iterate" tag');
+  }
+
+  if (!helpers.isValidShortName(operand1)) {
+    throw new Error('Invalid arguments (' + operand1 + ') passed to "iterate" tag');
+  }
+
+  if (!helpers.isValidName(operand2.name)) {
+    throw new Error('Invalid arguments (' + operand2.name + ') passed to "iterate" tag');
+  }
+
+  if (!helpers.isValidName(operand3.name)) {
+    throw new Error('Invalid arguments (' + operand3.name + ') passed to "iterate" tag');
+  }
+
+  operand1 = helpers.escapeVarName(operand1);
+
+  output = '(function () {' +
+    helpers.setVar('__iterFrom', operand2) +
+    helpers.setVar('__iterTo', operand3) +
+    '   for (var i = Number(__iterFrom); i <= Number(__iterTo); i++) {\n' +
+    '       _context["' + operand1 + '"] = i;\n' +
+    parser.compile.call(this, indent + '    ') +
+    '   }\n' +
+    '})();';
+
+  return output;
+};
+module.exports.ends = true;

--- a/tests/node/tags/iterate.test.js
+++ b/tests/node/tags/iterate.test.js
@@ -1,0 +1,22 @@
+var require = require('../testutils').require,
+  expect = require('expect.js'),
+  swig = require('../../lib/swig');
+
+describe('Tag: iterate', function () {
+  beforeEach(function () {
+    swig.init({ allowErrors: true });
+  });
+
+  // it('simple test', function () {
+  //   var iterate_tmpl = [
+  //     '{% iterate item 1 to 3 %}',
+  //     '<li>{{item}}</li>',
+  //     '{% enditerate %}'
+  //   ].join('\n'),
+
+  //   tpl = swig.compile(iterate_tmpl);
+
+  //   expect(tpl({})).to.equal('<li>1</li><li>2</li><li>3</li>');
+
+  // });
+});


### PR DESCRIPTION
# Include
- iteration tag
- no testing code, sorry about my poor skill :(  

plz, make better one. 
# Usage

```
<select id="birth_year" name="birth_year">
    {% set stYear = 1950 %}
    {% set edYear = 1999 %}
    {% iterate item with stYear to edYear %}
    <option value="{{ item }}">{{ item }}</option>
    {% enditerate %}
</select>
```
# Comment

I love this killing 'swig' template for node.
this good for me. I used this all my project. 
some time I have needed simple iteration tag
Is this useful? nor drop request. 
I don't care for

Always thanks this code :)
