### PR TITLE
add a [failing] test for setting object literal property using the "set" tag based on vars in the current template context

### DIFF
--- a/tests/node/tags/set.test.js
+++ b/tests/node/tags/set.test.js
@@ -43,4 +43,13 @@ describe('Tag: set', function () {
     expect(swig.compile('{% set foo = 1 %} {% set foo = foo|add(1) %}{% set foo = foo|add(1) %}{{ foo|add(1) }}')())
       .to.equal(' 4');
   });
+
+  it('set object literal properties from vars in current context', function () {
+    expect(swig.compile('{% set foo = "bar" %}{% set qux = {"foo": foo, "foo2": "bar2"} %}{{ qux.foo }}-{{ qux.foo2 }}-{{ foo }}')())
+      .to.equal('bar-bar2-bar');
+
+    expect(swig.compile('{% set qux = {"foo": foo, "foo2": "bar2"} %}{{ qux.foo }}-{{ qux.foo2 }}-{{ foo }}')({foo: 'bar'}))
+      .to.equal('bar-bar2-bar');
+  });
+
 });


### PR DESCRIPTION
this PR contains a couple of additions to the unit tests for the "set" tag showing that it is not possible to use existing template vars to create a new object literal with "set".

Why would that be useful? I would like to be able to use an "include" in "for" loop, e.g. 

```
                {% for job in jobs %}
                    {% set ctx = {job: job, foo: 'bar'} %}
                    {% include 'partials/job-row.html' with ctx %}
                {% endfor %}
```

I'd like to be able to have reusable 'item' templates that are included within a loop from multiple templates ... currently there seems no way to supply the included template with a suitable 'context' (containing the current item in the outer loop) 

The added tests define the problem ... I am currently at a loss as to how implement the extension to the "set" tag that I am suggesting.

Questions:
1. Is extending the "set" tag to allow setting of object literal properties to the value of existing template vars something you would consider including?
2. Is there a easier/better way of achieving the same result (i.e. should I be using the template engine differently to tackle the problem I have)? 
3. assuming 'yes' for question 1 and 'no' for question 2, would you consider implementing the requested change to the "set" tag? if not would you be able to give a hint or two as to where to start with regard to implementing this so I could have a stab at it myself?
