### PR TITLE
bug for nested variable not usable in `for` tag

### DIFF
--- a/lib/tags/for.js
+++ b/lib/tags/for.js
@@ -22,10 +22,6 @@ module.exports = function (indent, parser) {
     throw new Error('Invalid arguments (' + operand1 + ') passed to "for" tag');
   }
 
-  if (!helpers.isValidName(operand2.name)) {
-    throw new Error('Invalid arguments (' + operand2.name + ') passed to "for" tag');
-  }
-
   operand1 = helpers.escapeVarName(operand1);
 
   loopShared = 'loop.index = __loopIndex + 1;\n' +


### PR DESCRIPTION
There is no need to validate the property `name` of variable `operand2`, because the variable name will be instead as `__loopIter`.

The validation cause syntax like `<% for item in pord.items %>` throw an error, which are availiable in fact.
