### PR TITLE
Update for.js to support twig-style key iterators

### DIFF
--- a/lib/tags/for.js
+++ b/lib/tags/for.js
@@ -18,6 +18,16 @@ module.exports = function (indent, parser) {
     throw new Error('Invalid syntax in "for" tag');
   }
 
+  var key = operand1.split(",");
+  if (key.length==1) {
+    operand1 = key[0];
+    key = null;
+  }
+  else {
+    operand1 = key[1];
+    key = key[0];
+  }
+
   if (!helpers.isValidShortName(operand1)) {
     throw new Error('Invalid arguments (' + operand1 + ') passed to "for" tag');
   }
@@ -29,6 +39,7 @@ module.exports = function (indent, parser) {
     'loop.first = (__loopIndex === 0);\n' +
     'loop.last = (__loopIndex === __loopLength - 1);\n' +
     '_context["' + operand1 + '"] = __loopIter[loop.key];\n' +
+    (key == null ? '' : key + ' = loop.key;\n') +
     parser.compile.apply(this, [indent + '   ']);
 
   out = '(function () {\n' +


### PR DESCRIPTION
Swig uses "loop.key" where twig uses "for key,data in object". 
This quick hack allows this approach (which in our case is relevant in migrating from Twig to Swig).
