### PR TITLE
Change Browser/NodeJS detection to look for module.exports instead of window

### DIFF
--- a/lib/swig.js
+++ b/lib/swig.js
@@ -137,7 +137,7 @@ exports.compileFile = function (filepath, forceAllowErrors) {
     return CACHE[filepath];
   }
 
-  if (typeof process === 'undefined') {
+  if (!(typeof global !== 'undefined' && global.process)) {
     throw new TemplateError({ stack: 'You must pre-compile all templates in-browser. Use `swig.compile(template);`.' });
   }
 

--- a/tests/node/swig.test.js
+++ b/tests/node/swig.test.js
@@ -87,7 +87,7 @@ describe('swig.compileFile', function () {
   it('throws in a browser context', function () {
     swig.init({});
     var fn = function () { swig.compileFile('foobar'); };
-    if (typeof process !== 'undefined') {
+    if (typeof global !== 'undefined' && global.process) {
       // Running in Node
       expect(fn).to.not.throwException();
     } else {


### PR DESCRIPTION
If you use Swig with [Node-Webkit](https://github.com/rogerwang/node-webkit) (runs NodeJS modules inside Webkit) then Swig will not let you use swig.compileFile().

This is because Swig is currently checking if `window` exists. This is fine for most cases - but in Node-Webkit `window` does exist!

I've simply changed it to make sure `module.exports` does exist. 
