### PR TITLE
pass the template when processing parent

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -487,7 +487,7 @@ exports.compile = function compile(indent, context, template) {
                 token.line + '.');
       }
 
-      code += compile.call(parentBlock, indent + '  ', context);
+      code += compile.call(parentBlock, indent + '  ', context, template);
     } else if (token.hasOwnProperty("compile")) {
       if (token.strip.start && token.tokens.length && typeof token.tokens[0] === 'string') {
         token.tokens[0] = token.tokens[0].replace(/^\s+/, '');


### PR DESCRIPTION
Otherwise it somehow gets lost sometimes for following blocks. I have to admit that I'm not 100% certain that this is the right fix, but it does cause things to behave correctly (instead of crashing) for me.
