### PR TITLE
Added patch and test case for object prototypal inheritance

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -265,7 +265,7 @@ TokenParser.prototype = {
         if (i === 0) {
           return;
         }
-        build += ' && ' + c + '.hasOwnProperty("' + v + '")';
+        build += ' && "' + v + '" in ' + c;
         c += '.' + v;
       });
       build += ')';

--- a/tests/variables.test.js
+++ b/tests/variables.test.js
@@ -32,7 +32,8 @@ var cases = {
   ],
   'can include objects': [
     { c: '{{ {0: 1, a: "b"} }}', e: '[object Object]' },
-    { c: '{{ Object.keys({ 0: 1, a: "b" }) }}', e: '0,a' }
+    { c: '{{ Object.keys({ 0: 1, a: "b" }) }}', e: '0,a' },
+    { c: '{{ o.foo() }}', e: 'bar'}
   ],
   'can include arrays': [
     { c: '{{ [0, 1, 3] }}', e: '0,1,3' }
@@ -73,7 +74,8 @@ describe('Variables', function () {
     food: { a: 'tacos' },
     g: { '0': { q: { c: { b: { foo: 'hi!' }}}}},
     h: { g: {  i: 'q' } },
-    i: 'foo'
+    i: 'foo',
+    o: Object.create({ foo: function () { return 'bar'; } })
   }};
   _.each(cases, function (cases, description) {
     describe(description, function () {


### PR DESCRIPTION
Variable parser did not allow access to prototypally inherited properties (like Backbone's inheritance model).  Changed "hasOwnProperty" check to "in" format.  It seems like this could break something, but all tests pass.
