### PR TITLE
Don't auto-escape any function output

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -52,13 +52,12 @@ function escapeRegExp(str) {
  * @class
  * @param {array}   tokens     Pre-split tokens read by the Lexer.
  * @param {object}  filters    Keyed object of filters that may be applied to variables.
- * @param {array}   macros     List of macros registered in the template.
  * @param {boolean} autoescape Whether or not this should be autoescaped.
  * @param {number}  line       Beginning line number for the first token.
  * @param {string}  [filename] Name of the file being parsed.
  * @private
  */
-function TokenParser(tokens, filters, macros, autoescape, line, filename) {
+function TokenParser(tokens, filters, autoescape, line, filename) {
   this.out = [];
   this.state = [];
   this.filterApplyIdx = [];
@@ -66,7 +65,6 @@ function TokenParser(tokens, filters, macros, autoescape, line, filename) {
   this.line = line;
   this.filename = filename;
   this.filters = filters;
-  this.macros = macros;
   this.escape = autoescape;
 
   this.parse = function () {
@@ -208,9 +206,7 @@ TokenParser.prototype = {
       self.out.push('((typeof ' + match + ' !== "undefined") ? ' + match +
         ' : ((typeof _ctx.' + match + ' !== "undefined") ? _ctx.' + match +
         ' : _fn))(');
-      if (self.macros.indexOf(match) !== -1) {
-        self.escape = false;
-      }
+      self.escape = false;
       if (token.type === _t.FUNCTIONEMPTY) {
         self.out[self.out.length - 1] = self.out[self.out.length - 1] + ')';
       } else {
@@ -227,9 +223,7 @@ TokenParser.prototype = {
           temp = prevToken.match.split('.').slice(0, -1);
           self.out.push(' || _fn).call(' + self.checkMatch(temp));
           self.state.push(_t.METHODOPEN);
-          if (self.macros.indexOf(prevToken.match) !== -1) {
-            self.escape = false;
-          }
+          self.escape = false;
         } else {
           self.out.push(' || _fn)(');
         }
@@ -435,7 +429,6 @@ exports.parse = function (source, opts, tags, filters) {
     parent = null,
     tokens = [],
     blocks = {},
-    macros = [],
     inRaw = false,
     stripNext;
 
@@ -451,7 +444,7 @@ exports.parse = function (source, opts, tags, filters) {
       parser,
       out;
 
-    parser = new TokenParser(tokens, filters, macros, escape, line, opts.filename);
+    parser = new TokenParser(tokens, filters, escape, line, opts.filename);
     out = parser.parse().join('');
 
     if (parser.state.length) {
@@ -513,7 +506,7 @@ exports.parse = function (source, opts, tags, filters) {
     }
 
     tokens = lexer.read(utils.strip(chunks.join(' ')));
-    parser = new TokenParser(tokens, filters, macros, false, line, opts.filename);
+    parser = new TokenParser(tokens, filters, false, line, opts.filename);
     tag = tags[tagName];
 
     /**
@@ -612,10 +605,6 @@ exports.parse = function (source, opts, tags, filters) {
 
         if (token.block && (!stack.length || token.name === 'block')) {
           blocks[token.args.join('')] = token;
-        }
-
-        if (token.name === 'macro') {
-          macros.push(token.args[0]);
         }
       }
       if (inRaw && !token) {

--- a/lib/tags/import.js
+++ b/lib/tags/import.js
@@ -39,7 +39,6 @@ exports.parse = function (str, line, parser, types, stack, opts) {
     compiler = require('../parser').compile,
     parseOpts = { resolveFrom: opts.filename },
     compileOpts = utils.extend({}, opts, parseOpts),
-    macros = [],
     tokens,
     ctx;
 
@@ -56,7 +55,6 @@ exports.parse = function (str, line, parser, types, stack, opts) {
         macroName = token.args[0];
         out += token.compile(compiler, token.args, token.content, [], compileOpts) + '\n';
         out += 'exports.' + macroName + ' = ' + macroName + ';\n';
-        macros.push(macroName);
         self.out.push(out);
       });
       return;
@@ -77,10 +75,6 @@ exports.parse = function (str, line, parser, types, stack, opts) {
 
     ctx = token.match;
     self.out.push(ctx);
-    utils.each(macros, function (macro) {
-      self.macros.push(ctx + '.' + macro);
-    });
-
     return false;
   });
 


### PR DESCRIPTION
Discussed here: https://groups.google.com/forum/#!topic/swig-templates/tJG7dgxPOq8

Basically, the general consensus is that if you're sending a function to the template engine to be run and provide output, that your application will properly escape the output and Swig does not need to do so on its own. This will also fix a myriad of issues with macros, forcing them to never auto-escape.

Fixes gh-306
Fixes gh-302
Fixes gh-297
