### PR TITLE
Fixed transversal in parent tag loop.

### DIFF
--- a/lib/tags/parent.js
+++ b/lib/tags/parent.js
@@ -18,24 +18,15 @@ exports.compile = function (compiler, args, content, parents, options, blockName
     return '';
   }
 
-  var parentFile = args[0],
-    breaker = true,
-    l = parents.length,
-    i = 0,
-    parent,
-    block;
-
-  for (i; i < l; i += 1) {
-    parent = parents[i];
-    if (!parent.blocks || !parent.blocks.hasOwnProperty(blockName)) {
-      continue;
-    }
-    // Silly JSLint "Strange Loop" requires return to be in a conditional
-    if (breaker) {
-      block = parent.blocks[blockName];
+  var l = parents.length;
+  for (var i = 1; i < l; i += 1) {
+    var parent = parents[i];
+    if (parent.blocks && parent.blocks.hasOwnProperty(blockName)) {
+      var block = parent.blocks[blockName];
       return block.compile(compiler, [blockName], block.content, parents.slice(i + 1), options) + '\n';
     }
   }
+
 };
 
 exports.parse = function (str, line, parser, types, stack, opts) {


### PR DESCRIPTION
The parent tag, when transversing a block's parents looking for content to
render, started with the current block. This caused the initial content to be
double rendered. Fixed by starting the search at the first parent.

Also cleaned up the parent compile a bit.
