### PR TITLE
Added support for import-paths

### DIFF
--- a/lib/swig.js
+++ b/lib/swig.js
@@ -338,6 +338,8 @@ exports.Swig = function (opts) {
     }
 
     pathname = (options.resolveFrom) ? path.resolve(path.dirname(options.resolveFrom), pathname) : pathname;
+    var importPaths=self.options.importPaths || [];
+    pathname = path.resolve.apply(null,importPaths.concat([pathname]));
 
     if (!fs || !fs.readFileSync) {
       throw new Error('Unable to find file ' + pathname + ' because there is no filesystem to read from.');

--- a/tests/tags/import.test.js
+++ b/tests/tags/import.test.js
@@ -9,4 +9,19 @@ describe('Tag: import', function () {
       swig.render('{% import bar %}');
     }).to.throwError(/Unexpected variable "bar" on line 1\./);
   });
+
+  it('can import a macro', function () {
+    expect(
+      swig.render("{% import '"+__dirname+"/importtest.html' as test %}{{ test.test('d','e','f') }}")
+    ).to.match(/d e and f/);
+  });
+
+  it('obeys default search paths', function () {
+    swig.setDefaults({ importPaths:[__dirname] });
+    var initializedSwig=new swig.Swig();
+    expect(
+      initializedSwig.render("{% import 'importtest.html' as test %}{{ test.test('d','e','f') }}")
+    ).to.match(/d e and f/);
+  });
+
 });

--- a/tests/tags/importtest.html
+++ b/tests/tags/importtest.html
@@ -1,0 +1,3 @@
+{% macro test(a, b, c) %}
+<p>{{ a }} {{ b }} and {{ c }}</p>
+{% endmacro %}


### PR DESCRIPTION
Hi

I have added support for a new setting : "importPaths" which is an array of foldernames used by the parseFile function to resolve filenames. This makes it possible in the import tag to import macros from files without any path trusting that the proper include-paths have been set.

I need this to be able to make a npm package that encapsulates some functionality that includes both code for the backend and some swig templates for the templating. Using this I can have a folder inside the npm package that is added to the include-paths and when the package us updated, the templates will also be updated. I could just reference relatively from the template into the node_modules folder but I find that to be an ugly hack since that is not how it works for require'ing code.

I did a new testcase as well as a base testcase for the regular import-tag to make sure it works to actually import macros, something that was not tested before as far as I can see.

Alex
