### PR TITLE
async support

### DIFF
--- a/lib/swig.js
+++ b/lib/swig.js
@@ -1,10 +1,10 @@
 var fs = require('fs'),
-  path = require('path'),
-  utils = require('./utils'),
-  _tags = require('./tags'),
-  _filters = require('./filters'),
-  parser = require('./parser'),
-  dateformatter = require('./dateformatter');
+    path = require('path'),
+    utils = require('./utils'),
+    _tags = require('./tags'),
+    _filters = require('./filters'),
+    parser = require('./parser'),
+    dateformatter = require('./dateformatter');
 
 /**
  * Swig version number as a string.
@@ -26,32 +26,32 @@ exports.version = "1.0.0-rc3";
  * @property {CacheOptions} cache Cache control for templates. Defaults to saving in <code data-language="js">'memory'</code>. Send <code data-language="js">false</code> to disable. Send an object with <code data-language="js">get</code> and <code data-language="js">set</code> functions to customize.
  */
 var defaultOptions = {
-    autoescape: true,
-    varControls: ['{{', '}}'],
-    tagControls: ['{%', '%}'],
-    cmtControls: ['{#', '#}'],
-    locals: {},
-    /**
-     * Cache control for templates. Defaults to saving all templates into memory.
-     * @typedef {boolean|string|object} CacheOptions
-     * @example
-     * // Default
-     * swig.setDefaults({ cache: 'memory' });
-     * @example
-     * // Disables caching in Swig.
-     * swig.setDefaults({ cache: false });
-     * @example
-     * // Custom cache storage and retrieval
-     * swig.setDefaults({
+        autoescape: true,
+        varControls: ['{{', '}}'],
+        tagControls: ['{%', '%}'],
+        cmtControls: ['{#', '#}'],
+        locals: {},
+        /**
+         * Cache control for templates. Defaults to saving all templates into memory.
+         * @typedef {boolean|string|object} CacheOptions
+         * @example
+         * // Default
+         * swig.setDefaults({ cache: 'memory' });
+         * @example
+         * // Disables caching in Swig.
+         * swig.setDefaults({ cache: false });
+         * @example
+         * // Custom cache storage and retrieval
+         * swig.setDefaults({
      *   cache: {
      *     get: function (key) { ... },
      *     set: function (key, val) { ... }
      *   }
      * });
-     */
-    cache: 'memory'
-  },
-  defaultInstance;
+         */
+        cache: 'memory'
+    },
+    defaultInstance;
 
 /**
  * Empty function, used in templates.
@@ -60,6 +60,7 @@ var defaultOptions = {
  */
 function efn() { return ''; }
 
+
 /**
  * Validate the Swig options object.
  * @param  {?SwigOpts} options Swig options object.
@@ -67,34 +68,34 @@ function efn() { return ''; }
  * @private
  */
 function validateOptions(options) {
-  if (!options) {
-    return;
-  }
+    if (!options) {
+        return;
+    }
 
-  utils.each(['varControls', 'tagControls', 'cmtControls'], function (key) {
-    if (!options.hasOwnProperty(key)) {
-      return;
-    }
-    if (!utils.isArray(options[key]) || options[key].length !== 2) {
-      throw new Error('Option "' + key + '" must be an array containing 2 different control strings.');
-    }
-    if (options[key][0] === options[key][1]) {
-      throw new Error('Option "' + key + '" open and close controls must not be the same.');
-    }
-    utils.each(options[key], function (a, i) {
-      if (a.length < 2) {
-        throw new Error('Option "' + key + '" ' + ((i) ? 'open ' : 'close ') + 'control must be at least 2 characters. Saw "' + a + '" instead.');
-      }
+    utils.each(['varControls', 'tagControls', 'cmtControls'], function (key) {
+        if (!options.hasOwnProperty(key)) {
+            return;
+        }
+        if (!utils.isArray(options[key]) || options[key].length !== 2) {
+            throw new Error('Option "' + key + '" must be an array containing 2 different control strings.');
+        }
+        if (options[key][0] === options[key][1]) {
+            throw new Error('Option "' + key + '" open and close controls must not be the same.');
+        }
+        utils.each(options[key], function (a, i) {
+            if (a.length < 2) {
+                throw new Error('Option "' + key + '" ' + ((i) ? 'open ' : 'close ') + 'control must be at least 2 characters. Saw "' + a + '" instead.');
+            }
+        });
     });
-  });
 
-  if (options.hasOwnProperty('cache')) {
-    if (options.cache && options.cache !== 'memory') {
-      if (!options.cache.get || !options.cache.set) {
-        throw new Error('Invalid cache option ' + JSON.stringify(options.cache) + ' found. Expected "memory" or { get: function (key) { ... }, set: function (key, value) { ... } }.');
-      }
+    if (options.hasOwnProperty('cache')) {
+        if (options.cache && options.cache !== 'memory') {
+            if (!options.cache.get || !options.cache.set) {
+                throw new Error('Invalid cache option ' + JSON.stringify(options.cache) + ' found. Expected "memory" or { get: function (key) { ... }, set: function (key, value) { ... } }.');
+            }
+        }
     }
-  }
 }
 
 /**
@@ -114,14 +115,14 @@ function validateOptions(options) {
  * @return {undefined}
  */
 exports.setDefaults = function (options) {
-  validateOptions(options);
+    validateOptions(options);
 
-  var locals = utils.extend({}, defaultOptions.locals, options.locals || {});
+    var locals = utils.extend({}, defaultOptions.locals, options.locals || {});
 
-  utils.extend(defaultOptions, options);
-  defaultOptions.locals = locals;
+    utils.extend(defaultOptions, options);
+    defaultOptions.locals = locals;
 
-  defaultInstance.options = utils.extend(defaultInstance.options, options);
+    defaultInstance.options = utils.extend(defaultInstance.options, options);
 };
 
 /**
@@ -130,7 +131,7 @@ exports.setDefaults = function (options) {
  * @return {undefined}
  */
 exports.setDefaultTZOffset = function (offset) {
-  dateformatter.tzOffset = offset;
+    dateformatter.tzOffset = offset;
 };
 
 /**
@@ -148,294 +149,295 @@ exports.setDefaultTZOffset = function (offset) {
  * @return {object}      New Swig environment.
  */
 exports.Swig = function (opts) {
-  validateOptions(opts);
-  this.options = utils.extend({}, defaultOptions, opts || {});
-  this.cache = {};
-  this.extensions = {};
-  var self = this,
-    tags = _tags,
-    filters = _filters;
+    validateOptions(opts);
+    this.options = utils.extend({}, defaultOptions, opts || {});
+    this.cache = {};
+    this.extensions = {};
+    var self = this,
+        tags = _tags,
+        filters = _filters;
 
-  /**
-   * Get combined locals context.
-   * @param  {?SwigOpts} [options] Swig options object.
-   * @return {object}         Locals context.
-   * @private
-   */
-  function getLocals(options) {
-    if (!options || !options.locals) {
-      return self.options.locals;
+    /**
+     * Get combined locals context.
+     * @param  {?SwigOpts} [options] Swig options object.
+     * @return {object}         Locals context.
+     * @private
+     */
+    function getLocals(options) {
+        if (!options || !options.locals) {
+            return self.options.locals;
+        }
+
+        return utils.extend({}, self.options.locals, options.locals);
     }
 
-    return utils.extend({}, self.options.locals, options.locals);
-  }
+    /**
+     * Get compiled template from the cache.
+     * @param  {string} key           Name of template.
+     * @return {object|undefined}     Template function and tokens.
+     * @private
+     */
+    function cacheGet(key) {
+        if (!self.options.cache) {
+            return;
+        }
 
-  /**
-   * Get compiled template from the cache.
-   * @param  {string} key           Name of template.
-   * @return {object|undefined}     Template function and tokens.
-   * @private
-   */
-  function cacheGet(key) {
-    if (!self.options.cache) {
-      return;
+        if (self.options.cache === 'memory') {
+            return self.cache[key];
+        }
+
+        return self.options.cache.get(key);
     }
 
-    if (self.options.cache === 'memory') {
-      return self.cache[key];
+    /**
+     * Store a template in the cache.
+     * @param  {string} key Name of template.
+     * @param  {object} val Template function and tokens.
+     * @return {undefined}
+     * @private
+     */
+    function cacheSet(key, val) {
+        if (!self.options.cache) {
+            return;
+        }
+
+        if (self.options.cache === 'memory') {
+            self.cache[key] = val;
+            return;
+        }
+
+        self.options.cache.set(key, val);
     }
 
-    return self.options.cache.get(key);
-  }
-
-  /**
-   * Store a template in the cache.
-   * @param  {string} key Name of template.
-   * @param  {object} val Template function and tokens.
-   * @return {undefined}
-   * @private
-   */
-  function cacheSet(key, val) {
-    if (!self.options.cache) {
-      return;
-    }
-
-    if (self.options.cache === 'memory') {
-      self.cache[key] = val;
-      return;
-    }
-
-    self.options.cache.set(key, val);
-  }
-
-  /**
-   * Clears the in-memory template cache.
-   *
-   * @example
-   * swig.invalidateCache();
-   *
-   * @return {undefined}
-   */
-  this.invalidateCache = function () {
-    if (self.options.cache === 'memory') {
-      self.cache = {};
-    }
-  };
-
-  /**
-   * Add a custom filter for swig variables.
-   *
-   * @example
-   * function replaceMs(input) { return input.replace(/m/g, 'f'); }
-   * swig.setFilter('replaceMs', replaceMs);
-   * // => {{ "onomatopoeia"|replaceMs }}
-   * // => onofatopeia
-   *
-   * @param {string}    name    Name of filter, used in templates. <strong>Will</strong> overwrite previously defined filters, if using the same name.
-   * @param {function}  method  Function that acts against the input. See <a href="/docs/filters/#custom">Custom Filters</a> for more information.
-   * @return {undefined}
-   */
-  this.setFilter = function (name, method) {
-    if (typeof method !== "function") {
-      throw new Error('Filter "' + name + '" is not a valid function.');
-    }
-    filters[name] = method;
-  };
-
-  /**
-   * Add a custom tag. To expose your own extensions to compiled template code, see <code data-language="js">swig.setExtension</code>.
-   *
-   * For a more in-depth explanation of writing custom tags, see <a href="../extending/#tags">Custom Tags</a>.
-   *
-   * @example
-   * var tacotag = require('./tacotag');
-   * swig.setTag('tacos', tacotag.parse, tacotag.compile, tacotag.ends, tacotag.blockLevel);
-   * // => {% tacos %}Make this be tacos.{% endtacos %}
-   * // => Tacos tacos tacos tacos.
-   *
-   * @param  {string} name      Tag name.
-   * @param  {function} parse   Method for parsing tokens.
-   * @param  {function} compile Method for compiling renderable output.
-   * @param  {boolean} [ends=false]     Whether or not this tag requires an <i>end</i> tag.
-   * @param  {boolean} [blockLevel=false] If false, this tag will not be compiled outside of <code>block</code> tags when extending a parent template.
-   * @return {undefined}
-   */
-  this.setTag = function (name, parse, compile, ends, blockLevel) {
-    if (typeof parse !== 'function') {
-      throw new Error('Tag "' + name + '" parse method is not a valid function.');
-    }
-
-    if (typeof compile !== 'function') {
-      throw new Error('Tag "' + name + '" compile method is not a valid function.');
-    }
-
-    tags[name] = {
-      parse: parse,
-      compile: compile,
-      ends: ends || false,
-      block: !!blockLevel
+    /**
+     * Clears the in-memory template cache.
+     *
+     * @example
+     * swig.invalidateCache();
+     *
+     * @return {undefined}
+     */
+    this.invalidateCache = function () {
+        if (self.options.cache === 'memory') {
+            self.cache = {};
+        }
     };
-  };
 
-  /**
-   * Add extensions for custom tags. This allows any custom tag to access a globally available methods via a special globally available object, <var>_ext</var>, in templates.
-   *
-   * @example
-   * swig.setExtension('trans', function (v) { return translate(v); });
-   * function compileTrans(compiler, args, content, parent, options) {
+    /**
+     * Add a custom filter for swig variables.
+     *
+     * @example
+     * function replaceMs(input) { return input.replace(/m/g, 'f'); }
+     * swig.setFilter('replaceMs', replaceMs);
+     * // => {{ "onomatopoeia"|replaceMs }}
+     * // => onofatopeia
+     *
+     * @param {string}    name    Name of filter, used in templates. <strong>Will</strong> overwrite previously defined filters, if using the same name.
+     * @param {function}  method  Function that acts against the input. See <a href="/docs/filters/#custom">Custom Filters</a> for more information.
+     * @return {undefined}
+     */
+    this.setFilter = function (name, method) {
+        if (typeof method !== "function") {
+            throw new Error('Filter "' + name + '" is not a valid function.');
+        }
+        filters[name] = method;
+    };
+
+    /**
+     * Add a custom tag. To expose your own extensions to compiled template code, see <code data-language="js">swig.setExtension</code>.
+     *
+     * For a more in-depth explanation of writing custom tags, see <a href="../extending/#tags">Custom Tags</a>.
+     *
+     * @example
+     * var tacotag = require('./tacotag');
+     * swig.setTag('tacos', tacotag.parse, tacotag.compile, tacotag.ends, tacotag.blockLevel);
+     * // => {% tacos %}Make this be tacos.{% endtacos %}
+     * // => Tacos tacos tacos tacos.
+     *
+     * @param  {string} name      Tag name.
+     * @param  {function} parse   Method for parsing tokens.
+     * @param  {function} compile Method for compiling renderable output.
+     * @param  {boolean} [ends=false]     Whether or not this tag requires an <i>end</i> tag.
+     * @param  {boolean} [blockLevel=false] If false, this tag will not be compiled outside of <code>block</code> tags when extending a parent template.
+     * @return {undefined}
+     */
+    this.setTag = function (name, parse, compile, ends, blockLevel) {
+        if (typeof parse !== 'function') {
+            throw new Error('Tag "' + name + '" parse method is not a valid function.');
+        }
+
+        if (typeof compile !== 'function') {
+            throw new Error('Tag "' + name + '" compile method is not a valid function.');
+        }
+
+        tags[name] = {
+            parse: parse,
+            compile: compile,
+            ends: ends || false,
+            block: !!blockLevel
+        };
+    };
+
+    /**
+     * Add extensions for custom tags. This allows any custom tag to access a globally available methods via a special globally available object, <var>_ext</var>, in templates.
+     *
+     * @example
+     * swig.setExtension('trans', function (v) { return translate(v); });
+     * function compileTrans(compiler, args, content, parent, options) {
    *   return '_output += _ext.trans(' + args[0] + ');'
    * };
-   * swig.setTag('trans', parseTrans, compileTrans, true);
-   *
-   * @param  {string} name   Key name of the extension. Accessed via <code data-language="js">_ext[name]</code>.
-   * @param  {*}      object The method, value, or object that should be available via the given name.
-   * @return {undefined}
-   */
-  this.setExtension = function (name, object) {
-    self.extensions[name] = object;
-  };
+     * swig.setTag('trans', parseTrans, compileTrans, true);
+     *
+     * @param  {string} name   Key name of the extension. Accessed via <code data-language="js">_ext[name]</code>.
+     * @param  {*}      object The method, value, or object that should be available via the given name.
+     * @return {undefined}
+     */
+    this.setExtension = function (name, object) {
+        self.extensions[name] = object;
+    };
 
-  /**
-   * Parse a given source string into tokens.
-   *
-   * @param  {string} source  Swig template source.
-   * @param  {SwigOpts} [options={}] Swig options object.
-   * @return {object} parsed  Template tokens object.
-   * @private
-   */
-  this.parse = function (source, options) {
-    validateOptions(options);
+    /**
+     * Parse a given source string into tokens.
+     *
+     * @param  {string} source  Swig template source.
+     * @param  {SwigOpts} [options={}] Swig options object.
+     * @return {object} parsed  Template tokens object.
+     * @private
+     */
+    this.parse = function (source, options) {
+        validateOptions(options);
 
-    var locals = getLocals(options),
-      opts = {},
-      k;
+        var locals = getLocals(options),
+            opts = {},
+            k;
 
-    for (k in options) {
-      if (options.hasOwnProperty(k) && k !== 'locals') {
-        opts[k] = options[k];
-      }
+        for (k in options) {
+            if (options.hasOwnProperty(k) && k !== 'locals') {
+                opts[k] = options[k];
+            }
+        }
+
+        options = utils.extend({}, self.options, opts);
+        options.locals = locals;
+
+        return parser.parse(source, options, tags, filters);
+    };
+
+    /**
+     * Parse a given file into tokens.
+     *
+     * @param  {string} pathname  Full path to file to parse.
+     * @param  {SwigOpts} [options={}]   Swig options object.
+     * @return {object} parsed    Template tokens object.
+     * @private
+     */
+    this.parseFile = function (pathname, options) {
+        var src;
+
+        if (!options) {
+            options = {};
+        }
+
+        pathname = (options.resolveFrom) ? path.resolve(path.dirname(options.resolveFrom), pathname) : pathname;
+
+        if (!fs || !fs.readFileSync) {
+            throw new Error('Unable to find file ' + pathname + ' because there is no filesystem to read from.');
+        }
+        src = fs.readFileSync(pathname, 'utf8');
+
+        if (!options.filename) {
+            options = utils.extend({ filename: pathname }, options);
+        }
+
+        return self.parse(src, options);
+    };
+
+    /**
+     * Re-Map blocks within a list of tokens to the template's block objects.
+     * @param  {array}  tokens   List of tokens for the parent object.
+     * @param  {object} template Current template that needs to be mapped to the  parent's block and token list.
+     * @return {array}
+     * @private
+     */
+    function remapBlocks(blocks, tokens) {
+        return utils.map(tokens, function (token) {
+            var args = token.args ? token.args.join('') : '';
+            if (token.name === 'block' && blocks[args]) {
+                token = blocks[args];
+            }
+            if (token.content && token.content.length) {
+                token.content = remapBlocks(blocks, token.content);
+            }
+            return token;
+        });
     }
 
-    options = utils.extend({}, self.options, opts);
-    options.locals = locals;
-
-    return parser.parse(source, options, tags, filters);
-  };
-
-  /**
-   * Parse a given file into tokens.
-   *
-   * @param  {string} pathname  Full path to file to parse.
-   * @param  {SwigOpts} [options={}]   Swig options object.
-   * @return {object} parsed    Template tokens object.
-   * @private
-   */
-  this.parseFile = function (pathname, options) {
-    var src;
-
-    if (!options) {
-      options = {};
+    /**
+     * Import block-level tags to the token list that are not actual block tags.
+     * @param  {array} blocks List of block-level tags.
+     * @param  {array} tokens List of tokens to render.
+     * @return {undefined}
+     * @private
+     */
+    function importNonBlocks(blocks, tokens) {
+        utils.each(blocks, function (block) {
+            if (block.name !== 'block') {
+                tokens.unshift(block);
+            }
+        });
     }
 
-    pathname = (options.resolveFrom) ? path.resolve(path.dirname(options.resolveFrom), pathname) : pathname;
+    /**
+     * Recursively compile and get parents of given parsed token object.
+     *
+     * @param  {object} tokens    Parsed tokens from template.
+     * @param  {SwigOpts} [options={}]   Swig options object.
+     * @return {object}           Parsed tokens from parent templates.
+     * @private
+     */
+    function getParents(tokens, options) {
+        var blocks = {},
+            parentName = tokens.parent,
+            parentFiles = [],
+            parents = [],
+            parentFile,
+            parent,
+            l;
 
-    if (!fs || !fs.readFileSync) {
-      throw new Error('Unable to find file ' + pathname + ' because there is no filesystem to read from.');
-    }
-    src = fs.readFileSync(pathname, 'utf8');
+        while (parentName) {
+            if (!options || !options.filename) {
+                throw new Error('Cannot extend "' + parentName + '" because current template has no filename.');
+            }
 
-    if (!options.filename) {
-      options = utils.extend({ filename: pathname }, options);
-    }
+            parentFile = parentFile || options.filename;
+            parentFile = path.resolve(path.dirname(parentFile), parentName);
+            parent = self.parseFile(parentFile, utils.extend({}, options, { filename: parentFile }));
+            parentName = parent.parent;
 
-    return self.parse(src, options);
-  };
+            if (parentFiles.indexOf(parentFile) !== -1) {
+                throw new Error('Illegal circular extends of "' + parentFile + '".');
+            }
+            parentFiles.push(parentFile);
 
-  /**
-   * Re-Map blocks within a list of tokens to the template's block objects.
-   * @param  {array}  tokens   List of tokens for the parent object.
-   * @param  {object} template Current template that needs to be mapped to the  parent's block and token list.
-   * @return {array}
-   * @private
-   */
-  function remapBlocks(blocks, tokens) {
-    return utils.map(tokens, function (token) {
-      var args = token.args ? token.args.join('') : '';
-      if (token.name === 'block' && blocks[args]) {
-        token = blocks[args];
-      }
-      if (token.content && token.content.length) {
-        token.content = remapBlocks(blocks, token.content);
-      }
-      return token;
-    });
-  }
+            parents.push(parent);
+        }
 
-  /**
-   * Import block-level tags to the token list that are not actual block tags.
-   * @param  {array} blocks List of block-level tags.
-   * @param  {array} tokens List of tokens to render.
-   * @return {undefined}
-   * @private
-   */
-  function importNonBlocks(blocks, tokens) {
-    utils.each(blocks, function (block) {
-      if (block.name !== 'block') {
-        tokens.unshift(block);
-      }
-    });
-  }
+        // Remap each parents'(1) blocks onto its own parent(2), receiving the full token list for rendering the original parent(1) on its own.
+        l = parents.length;
+        for (l = parents.length - 2; l >= 0; l -= 1) {
+            parents[l].tokens = remapBlocks(parents[l].blocks, parents[l + 1].tokens);
+            importNonBlocks(parents[l].blocks, parents[l].tokens);
+        }
 
-  /**
-   * Recursively compile and get parents of given parsed token object.
-   *
-   * @param  {object} tokens    Parsed tokens from template.
-   * @param  {SwigOpts} [options={}]   Swig options object.
-   * @return {object}           Parsed tokens from parent templates.
-   * @private
-   */
-  function getParents(tokens, options) {
-    var parentName = tokens.parent,
-      parentFiles = [],
-      parents = [],
-      parentFile,
-      parent,
-      l;
-
-    while (parentName) {
-      if (!options || !options.filename) {
-        throw new Error('Cannot extend "' + parentName + '" because current template has no filename.');
-      }
-
-      parentFile = parentFile || options.filename;
-      parentFile = path.resolve(path.dirname(parentFile), parentName);
-      parent = self.parseFile(parentFile, utils.extend({}, options, { filename: parentFile }));
-      parentName = parent.parent;
-
-      if (parentFiles.indexOf(parentFile) !== -1) {
-        throw new Error('Illegal circular extends of "' + parentFile + '".');
-      }
-      parentFiles.push(parentFile);
-
-      parents.push(parent);
+        return parents;
     }
 
-    // Remap each parents'(1) blocks onto its own parent(2), receiving the full token list for rendering the original parent(1) on its own.
-    l = parents.length;
-    for (l = parents.length - 2; l >= 0; l -= 1) {
-      parents[l].tokens = remapBlocks(parents[l].blocks, parents[l + 1].tokens);
-      importNonBlocks(parents[l].blocks, parents[l].tokens);
-    }
-
-    return parents;
-  }
-
-  /**
-   * Pre-compile a source string into a cache-able template function.
-   *
-   * @example
-   * swig.precompile('{{ tacos }}');
-   * // => {
+    /**
+     * Pre-compile a source string into a cache-able template function.
+     *
+     * @example
+     * swig.precompile('{{ tacos }}');
+     * // => {
    * //      tpl: function (_swig, _locals, _filters, _utils, _fn) { ... },
    * //      tokens: {
    * //        name: undefined,
@@ -444,227 +446,270 @@ exports.Swig = function (opts) {
    * //        blocks: {}
    * //      }
    * //    }
-   *
-   * In order to render a pre-compiled template, you must have access to filters and utils from Swig. <var>efn</var> is simply an empty function that does nothing.
-   *
-   * @param  {string} source  Swig template source string.
-   * @param  {SwigOpts} [options={}] Swig options object.
-   * @return {object}         Renderable function and tokens object.
-   */
-  this.precompile = function (source, options) {
-    var tokens = self.parse(source, options),
-      parents = getParents(tokens, options),
-      tpl;
+     *
+     * In order to render a pre-compiled template, you must have access to filters and utils from Swig. <var>efn</var> is simply an empty function that does nothing.
+     *
+     * @param  {string} source  Swig template source string.
+     * @param  {SwigOpts} [options={}] Swig options object.
+     * @return {object}         Renderable function and tokens object.
+     */
+    this.precompile = function (source, options) {
+        var tokens = self.parse(source, options),
+            parents = getParents(tokens, options),
+            tpl;
 
-    if (parents.length) {
-      // Remap the templates first-parent's tokens using this template's blocks.
-      tokens.tokens = remapBlocks(tokens.blocks, parents[0].tokens);
-      importNonBlocks(tokens.blocks, tokens.tokens);
-    }
+        if (parents.length) {
+            // Remap the templates first-parent's tokens using this template's blocks.
+            tokens.tokens = remapBlocks(tokens.blocks, parents[0].tokens);
+            importNonBlocks(tokens.blocks, tokens.tokens);
+        }
 
-    tpl = new Function('_swig', '_ctx', '_filters', '_utils', '_fn',
-      '  var _ext = _swig.extensions,\n' +
-      '    _output = "";\n' +
-      parser.compile(tokens, parents, options) + '\n' +
-      '  return _output;\n'
-      );
+        tpl = new Function('_swig', '_ctx', '_filters', '_utils', '_fn', '_asyncCb',
+            '  var _ext = _swig.extensions,\n' +
+                '    _output = "";\n' +
+                parser.compile(tokens, parents, options) + '\n' +
+                '  return _output;\n'
+        );
+        console.log(tpl.toString());
+        return { tpl: tpl, tokens: tokens };
+    };
 
-    return { tpl: tpl, tokens: tokens };
-  };
+    /**
+     * Compile and render a template string for final output.
+     *
+     * @example
+     * swig.render('{{ tacos }}', { locals: { tacos: 'Tacos!!!!' }});
+     * // => Tacos!!!!
+     *
+     * When rendering a source string, a file path should be specified in the options object in order for <var>extends</var>, <var>include</var>, and <var>import</var> to work properly. Do this by adding <code data-language="js">{ filename: '/absolute/path/to/mytpl.html' }</code> to the options argument.
+     *
+     * @param  {string} source    Swig template source string.
+     * @param  {SwigOpts} [options={}] Swig options object.
+     * @return {string}           Rendered output.
+     */
+    this.render = function (source, options,cb) {
+        return exports.compile(source, options)(null, cb);
+    };
 
-  /**
-   * Compile and render a template string for final output.
-   *
-   * @example
-   * swig.render('{{ tacos }}', { locals: { tacos: 'Tacos!!!!' }});
-   * // => Tacos!!!!
-   *
-   * When rendering a source string, a file path should be specified in the options object in order for <var>extends</var>, <var>include</var>, and <var>import</var> to work properly. Do this by adding <code data-language="js">{ filename: '/absolute/path/to/mytpl.html' }</code> to the options argument.
-   *
-   * @param  {string} source    Swig template source string.
-   * @param  {SwigOpts} [options={}] Swig options object.
-   * @return {string}           Rendered output.
-   */
-  this.render = function (source, options) {
-    return exports.compile(source, options)();
-  };
-
-  /**
-   * Compile and render a template file for final output. This is most useful for libraries like Express.js.
-   *
-   * @example
-   * swig.renderFile('./template.html', {}, function (err, output) {
+    /**
+     * Compile and render a template file for final output. This is most useful for libraries like Express.js.
+     *
+     * @example
+     * swig.renderFile('./template.html', {}, function (err, output) {
    *   if (err) {
    *     throw err;
    *   }
    *   console.log(output);
    * });
-   *
-   * @example
-   * swig.renderFile('./template.html', {});
-   * // => output
-   *
-   * @param  {string}   pathName    File location.
-   * @param  {object}   [locals={}] Template variable context.
-   * @param  {Function} [cb] Asyncronous callback function. If not provided, <var>compileFile</var> will run syncronously.
-   * @return {string}             Rendered output.
-   */
-  this.renderFile = function (pathName, locals, cb) {
-    if (cb) {
-      exports.compileFile(pathName, {}, function (err, fn) {
-        if (err) {
-          cb(err);
-          return;
+     *
+     * @example
+     * swig.renderFile('./template.html', {});
+     * // => output
+     *
+     * @param  {string}   pathName    File location.
+     * @param  {object}   [locals={}] Template variable context.
+     * @param  {Function} [cb] Asyncronous callback function. If not provided, <var>compileFile</var> will run syncronously.
+     * @return {string}             Rendered output.
+     */
+    this.renderFile = function (pathName, locals, cb) {
+        var out;
+        if (cb) {
+            exports.compileFile(pathName, {}, function (err, fn) {
+                if (err) {
+                    cb(err);
+                    return;
+                }
+                fn(locals, function(output)
+                {
+                    cb(null,  output);
+                });
+            });
+            return;
         }
-        cb(null, fn(locals));
-      });
-      return;
-    }
 
-    return exports.compileFile(pathName)(locals);
-  };
+        return exports.compileFile(pathName)(locals);
+    };
 
-  /**
-   * Compile string source into a renderable template function.
-   *
-   * @example
-   * var tpl = swig.compile('{{ tacos }}');
-   * // => {
+    /**
+     * Compile string source into a renderable template function.
+     *
+     * @example
+     * var tpl = swig.compile('{{ tacos }}');
+     * // => {
    * //      [Function: compiled]
    * //      parent: null,
    * //      tokens: [{ compile: [Function] }],
    * //      blocks: {}
    * //    }
-   * tpl({ tacos: 'Tacos!!!!' });
-   * // => Tacos!!!!
-   *
-   * When compiling a source string, a file path should be specified in the options object in order for <var>extends</var>, <var>include</var>, and <var>import</var> to work properly. Do this by adding <code data-language="js">{ filename: '/absolute/path/to/mytpl.html' }</code> to the options argument.
-   *
-   * @param  {string} source    Swig template source string.
-   * @param  {SwigOpts} [options={}] Swig options object.
-   * @return {function}         Renderable function with keys for parent, blocks, and tokens.
-   */
-  this.compile = function (source, options) {
-    var key = options ? options.filename : null,
-      cached = key ? cacheGet(key) : null,
-      context,
-      contextLength,
-      pre;
+     * tpl({ tacos: 'Tacos!!!!' });
+     * // => Tacos!!!!
+     *
+     * When compiling a source string, a file path should be specified in the options object in order for <var>extends</var>, <var>include</var>, and <var>import</var> to work properly. Do this by adding <code data-language="js">{ filename: '/absolute/path/to/mytpl.html' }</code> to the options argument.
+     *
+     * @param  {string} source    Swig template source string.
+     * @param  {SwigOpts} [options={}] Swig options object.
+     * @return {function}         Renderable function with keys for parent, blocks, and tokens.
+     */
+    this.compile = function (source, options) {
+        var key = options ? options.filename : null,
+            cached = key ? cacheGet(key) : null,
+            context,
+            contextLength,
+            pre,
+            tpl;
 
-    if (cached) {
-      return cached;
-    }
+        if (cached) {
+            return cached;
+        }
 
-    context = getLocals(options);
-    contextLength = utils.keys(context).length;
-    pre = this.precompile(source, options);
+        context = getLocals(options);
+        contextLength = utils.keys(context).length;
+        pre = this.precompile(source, options);
 
-    function compiled(locals) {
-      var lcls;
-      if (locals && contextLength) {
-        lcls = utils.extend({}, context, locals);
-      } else if (locals && !contextLength) {
-        lcls = locals;
-      } else if (!locals && contextLength) {
-        lcls = context;
-      } else {
-        lcls = {};
-      }
-      return pre.tpl(self, lcls, filters, utils, efn);
-    }
+        function compiled(locals,cb) {
+            var lcls;
+            if (locals && contextLength) {
+                lcls = utils.extend({}, context, locals);
+            } else if (locals && !contextLength) {
+                lcls = locals;
+            } else if (!locals && contextLength) {
+                lcls = context;
+            } else {
+                lcls = {};
+            }
 
-    utils.extend(compiled, pre.tokens);
+            /* Async Support */
+            var asyncOutputBlocks = [];
+            function asyncContentRegister(currentOutputLength, func)
+            {
+                var asyncOutputBlock = {pos: currentOutputLength, content: null, finished: false };
+                asyncOutputBlocks.push(asyncOutputBlock);
+                setTimeout(function()
+                {
+                    func(function(blockOutput)
+                    {
+                        if (asyncOutputBlock.finished)
+                            return;
 
-    if (key) {
-      cacheSet(key, compiled);
-    }
+                        asyncOutputBlock.finished = true;
+                        asyncOutputBlock.content = blockOutput || '';
+                        if (cb && !utils.some(asyncOutputBlocks, function(block)
+                        {
+                            return block.finished == false
+                        }) )
+                        {
+                            var extraContentLength = 0;
+                            var newOutput = output;
+                            utils.each(asyncOutputBlocks, function(block)
+                            {
+                                newOutput = newOutput.substring(0, block.pos + extraContentLength) + block.content + newOutput.substr(block.pos + extraContentLength);
+                                extraContentLength += block.content.length;
+                            })
+                            if (cb)
+                                cb(null, newOutput);
+                        }
+                    })
+                },0);
+            }
 
-    return compiled;
-  };
+            var output = pre.tpl(self, lcls, filters, utils, efn, asyncContentRegister);
+            if (!cb)
+                return output;
+        }
 
-  /**
-   * Compile a source file into a renderable template function.
-   *
-   * @example
-   * var tpl = swig.compileFile('./mytpl.html');
-   * // => {
+        utils.extend(compiled, pre.tokens);
+
+        if (key) {
+            cacheSet(key, compiled);
+        }
+
+        return compiled;
+    };
+
+    /**
+     * Compile a source file into a renderable template function.
+     *
+     * @example
+     * var tpl = swig.compileFile('./mytpl.html');
+     * // => {
    * //      [Function: compiled]
    * //      parent: null,
    * //      tokens: [{ compile: [Function] }],
    * //      blocks: {}
    * //    }
-   * tpl({ tacos: 'Tacos!!!!' });
-   * // => Tacos!!!!
-   *
-   * @example
-   * swig.compileFile('/myfile.txt', { varControls: ['<%=', '=%>'], tagControls: ['<%', '%>']});
-   * // => will compile 'myfile.txt' using the var and tag controls as specified.
-   *
-   * @param  {string} pathname  File location.
-   * @param  {SwigOpts} [options={}] Swig options object.
-   * @param  {Function} [cb] Asyncronous callback function. If not provided, <var>compileFile</var> will run syncronously.
-   * @return {function}         Renderable function with keys for parent, blocks, and tokens.
-   */
-  this.compileFile = function (pathname, options, cb) {
-    var src, cached;
+     * tpl({ tacos: 'Tacos!!!!' });
+     * // => Tacos!!!!
+     *
+     * @example
+     * swig.compileFile('/myfile.txt', { varControls: ['<%=', '=%>'], tagControls: ['<%', '%>']});
+     * // => will compile 'myfile.txt' using the var and tag controls as specified.
+     *
+     * @param  {string} pathname  File location.
+     * @param  {SwigOpts} [options={}] Swig options object.
+     * @param  {Function} [cb] Asyncronous callback function. If not provided, <var>compileFile</var> will run syncronously.
+     * @return {function}         Renderable function with keys for parent, blocks, and tokens.
+     */
+    this.compileFile = function (pathname, options, cb) {
+        var src, cached;
 
-    if (!options) {
-      options = {};
-    }
-
-    pathname = (options.resolveFrom) ? path.resolve(path.dirname(options.resolveFrom), pathname) : pathname;
-    if (!options.filename) {
-      options = utils.extend({ filename: pathname }, options);
-    }
-    cached = cacheGet(pathname);
-
-    if (cached) {
-      if (cb) {
-        cb(null, cached);
-        return;
-      }
-      return cached;
-    }
-
-    if (!fs || !fs.readFileSync) {
-      throw new Error('Unable to find file ' + pathname + ' because there is no filesystem to read from.');
-    }
-
-    if (cb) {
-      fs.readFile(pathname, 'utf8', function (err, src) {
-        if (err) {
-          cb(err);
-          return;
+        if (!options) {
+            options = {};
         }
-        cb(err, self.compile(src, options));
-      });
-      return;
-    }
 
-    src = fs.readFileSync(pathname, 'utf8');
-    return self.compile(src, options);
-  };
+        pathname = (options.resolveFrom) ? path.resolve(path.dirname(options.resolveFrom), pathname) : pathname;
+        if (!options.filename) {
+            options = utils.extend({ filename: pathname }, options);
+        }
+        cached = cacheGet(pathname);
 
-  /**
-   * Run a pre-compiled template function. This is most useful in the browser when you've pre-compiled your templates with the Swig command-line tool.
-   *
-   * @example
-   * $ swig compile ./mytpl.html --wrap-start="var mytpl = " > mytpl.js
-   * @example
-   * <script src="mytpl.js"></script>
-   * <script>
-   *   swig.run(mytpl, {});
-   *   // => "rendered template..."
-   * </script>
-   *
-   * @param  {function} tpl       Pre-compiled Swig template function. Use the Swig CLI to compile your templates.
-   * @param  {object} [locals={}] Template variable context.
-   * @return {string}             Rendered output.
-   */
-  this.run = function (tpl, locals) {
-    var context = getLocals({ locals: locals });
-    return tpl(self, context, filters, utils, efn);
-  };
+        if (cached) {
+            if (cb) {
+                cb(null, cached);
+                return;
+            }
+            return cached;
+        }
+
+        if (!fs || !fs.readFileSync) {
+            throw new Error('Unable to find file ' + pathname + ' because there is no filesystem to read from.');
+        }
+
+        if (cb) {
+            fs.readFile(pathname, 'utf8', function (err, src) {
+                if (err) {
+                    cb(err);
+                    return;
+                }
+                cb(err, self.compile(src, options));
+            });
+            return;
+        }
+
+        src = fs.readFileSync(pathname, 'utf8');
+        return self.compile(src, options);
+    };
+
+    /**
+     * Run a pre-compiled template function. This is most useful in the browser when you've pre-compiled your templates with the Swig command-line tool.
+     *
+     * @example
+     * $ swig compile ./mytpl.html --wrap-start="var mytpl = " > mytpl.js
+     * @example
+     * <script src="mytpl.js"></script>
+     * <script>
+     *   swig.run(mytpl, {});
+     *   // => "rendered template..."
+     * </script>
+     *
+     * @param  {function} tpl       Pre-compiled Swig template function. Use the Swig CLI to compile your templates.
+     * @param  {object} [locals={}] Template variable context.
+     * @param  {string} [pathName]  Path of the file. Used for relative include lookups.
+     * @return {string}             Rendered output.
+     */
+    this.run = function (tpl, locals, pathName) {
+        var context = getLocals({ locals: locals });
+        return tpl(self, context, filters, utils, efn);
+    };
 };
 
 /*!
@@ -682,3 +727,4 @@ exports.render = defaultInstance.render;
 exports.renderFile = defaultInstance.renderFile;
 exports.run = defaultInstance.run;
 exports.invalidateCache = defaultInstance.invalidateCache;
+

--- a/lib/tags.js
+++ b/lib/tags.js
@@ -1,3 +1,4 @@
+exports.async = require('./tags/async');
 exports.autoescape = require('./tags/autoescape');
 exports.block = require('./tags/block');
 exports.else = require('./tags/else');

--- a/lib/tags/async.js
+++ b/lib/tags/async.js
@@ -1,0 +1,27 @@
+/**
+ * Support async execution of the enclosed block.  Use for helper functions that must execute async.  Helper func calls done when complete with output <code>done('some output')</code>
+ *
+ * @alias async
+ *
+ * @example
+ * {% async %}
+ * {{ myfunc(done) }}
+ * {% endasync %}
+ *
+ */
+exports.compile = function (compiler, args, content) {
+    return [
+        '(function () {\n',
+        '  _asyncCb(_output.length, function(done) { \n',
+        '  var _output = "";\n' +
+        '  ' + compiler(content) + '\n',
+        '  });\n',
+        '})();\n'
+    ].join('');
+
+};
+
+exports.parse = function (str, line, parser, types, stack) {
+    return true;
+};
+exports.ends = true;

--- a/tests/tags/async.test.js
+++ b/tests/tags/async.test.js
@@ -1,0 +1,18 @@
+var swig = require('../../lib/swig'),
+  expect = require('expect.js'),
+  _ = require('lodash'),
+  Swig = swig.Swig;
+
+
+describe('Tag: async', function () {
+
+    function func(done,arg) { done(arg + '!')};
+
+    it('can run asynchronously', function (done) {
+        swig.render('{% async %}{{ func(done,"OK") }}{% endasync %}', { func:func}, function (err, output) {
+            expect(output).to.equal('OK!');
+            done();
+        });
+    });
+
+});


### PR DESCRIPTION
Sorry bit of a reformatting issue in swig.js

Main changes are in Swig.precompile with addition of callback parameter to .render and .compile

Alternative is to not support blocks for {% async %) and instead limit it to calling a locals function e.g. 

```
{% async func(done) %}
```

Either way there is no impact on rest of the system and any generated compiler output can call _asyncCb() 
