### PR TITLE
Added patch to call the callback passed into compileFile in the event of an error thrown in compile

### DIFF
--- a/lib/swig.js
+++ b/lib/swig.js
@@ -636,7 +636,6 @@ exports.Swig = function (opts) {
           cb(err);
           return;
         }
-        
         var compiled;
 
         try {

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -187,6 +187,14 @@ describe('swig.compileFile', function () {
       }));
     });
   });
+
+  it('can use callback with errors', function (done) {
+    var errorTest = __dirname + '/cases-error/extends-non-existent.test.html';
+    expect(swig.compileFile(errorTest, {}, function (err) {
+      expect(err.errno).to.equal(34);
+      done();
+    }));
+  });
 });
 
 describe('swig.renderFile', function () {

--- a/tests/cases-error/extends-non-existent.test.html
+++ b/tests/cases-error/extends-non-existent.test.html
@@ -1,0 +1,1 @@
+{% extends 'does-not-exist.html' %}


### PR DESCRIPTION
When a callback is passed into compileFile in swig.js, this patch catches any errors thrown when calling compile and invokes the callback with an error instead.  

While this patch  doesn't make sure all calls are async when a callback is specified (a minor issue), this patch does address the main crux of issue #338, which is to ensure the callback is called instead of having the error be thrown.
