### PR TITLE
Fix a few references where `exports.fn` should be `this.fn`.

### DIFF
--- a/lib/swig.js
+++ b/lib/swig.js
@@ -486,7 +486,7 @@ exports.Swig = function (opts) {
    * @return {string}           Rendered output.
    */
   this.render = function (source, options) {
-    return exports.compile(source, options)();
+    return this.compile(source, options)();
   };
 
   /**
@@ -511,7 +511,7 @@ exports.Swig = function (opts) {
    */
   this.renderFile = function (pathName, locals, cb) {
     if (cb) {
-      exports.compileFile(pathName, {}, function (err, fn) {
+      this.compileFile(pathName, {}, function (err, fn) {
         if (err) {
           cb(err);
           return;
@@ -521,7 +521,7 @@ exports.Swig = function (opts) {
       return;
     }
 
-    return exports.compileFile(pathName)(locals);
+    return this.compileFile(pathName)(locals);
   };
 
   /**


### PR DESCRIPTION
We found that when setting delimiters and using Swig a la...

```
var renderer = new swig.Swig({
  varControls: ['<<<<', '>>>>']
});

renderer.renderFile('path/to/file', {}, someCallback);
```

...that the Swig default options were being used to render the file, instead of
the options that we had passed into the Swig constructor. This was due to the
fact that a couple of functions were referencing `exports` instead of `this`
when calling other methods, causing the `defaultInstance` to be the context for
these method calls, instead of the instance we created.

This change resolves our issue, and all tests pass. :)

Huge thanks to @diurnalist for helping to find and fix this issue!
