### PR TITLE
Fix 'extends' in browser.

### DIFF
--- a/lib/swig.js
+++ b/lib/swig.js
@@ -409,7 +409,11 @@ exports.Swig = function (opts) {
 
       parentFile = parentFile || options.filename;
       parentFile = path.resolve(path.dirname(parentFile), parentName);
-      parent = self.parseFile(parentFile, utils.extend({}, options, { filename: parentFile }));
+      if (cacheGet(parentFile) !== undefined) {
+        parent = cacheGet(parentFile);
+      } else {
+        parent = self.parseFile(parentFile, utils.extend({}, options, { filename: parentFile }));
+      }
       parentName = parent.parent;
 
       if (parentFiles.indexOf(parentFile) !== -1) {


### PR DESCRIPTION
This fixes #370
This doesn't fix 'include' though.

NOTE: this is merely for documentation purposes.
I would consider #377 as a fix for 'extend' and 'include' in the browser.
