### PR TITLE
Added support for optional raw arguments

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -576,7 +576,7 @@ exports.parse = function (source, opts, tags, filters) {
       escape = (args[0] !== 'false') ? args[0] : false;
       break;
     case 'raw':
-      inRaw = true;
+      inRaw = args[0] === undefined || args[0] === 'true';
       break;
     }
 

--- a/lib/tags/raw.js
+++ b/lib/tags/raw.js
@@ -10,14 +10,49 @@
  * {% raw %}{{ foobar }}{% endraw %}
  * // => {{ foobar }}
  *
+ * @example
+ * // bool = true
+ * {% raw bool %}{{ foobar }}{% endraw %}
+ * // => {{ foobar }}
+ *
+ * @exmaple
+ * // environment = 'pre-client'
+ * {% raw environment === 'pre-client' %}{{ foobar }}{% endraw %}
+ * // => {{ foobar }}
  */
 exports.compile = function (compiler, args, content, parents, options, blockName) {
   return compiler(content, parents, options, blockName);
 };
-exports.parse = function (str, line, parser) {
-  parser.on('*', function (token) {
-    throw new Error('Unexpected token "' + token.match + '" in raw tag on line ' + line + '.');
+exports.parse = function (str, line, parser, types) {
+  parser.on(types.COMPARATOR, function (token) {
+    if (this.isLast) {
+      throw new Error('Unexpected logic "' + token.match + '" on line ' + line + '.');
+    }
+    if (this.prevToken.type === types.NOT) {
+      throw new Error('Attempted logic "not ' + token.match + '" on line ' + line + '. Use !(foo ' + token.match + ') instead.');
+    }
+    this.out.push(token.match);
   });
+
+  parser.on(types.NOT, function (token) {
+    if (this.isLast) {
+      throw new Error('Unexpected logic "' + token.match + '" on line ' + line + '.');
+    }
+    this.out.push(token.match);
+  });
+
+  parser.on(types.BOOL, function (token) {
+    this.out.push(token.match);
+  });
+
+  parser.on(types.LOGIC, function (token) {
+    if (!this.out.length || this.isLast) {
+      throw new Error('Unexpected logic "' + token.match + '" on line ' + line + '.');
+    }
+    this.out.push(token.match);
+    this.filterApplyIdx.pop();
+  });
+
   return true;
 };
 exports.ends = true;

--- a/tests/tags/raw.test.js
+++ b/tests/tags/raw.test.js
@@ -25,9 +25,26 @@ describe('Tag: raw', function () {
       .to.equal('{# foo #}');
   });
 
-  it('does not accept arguments', function () {
-    expect(function () {
-      swig.render('{% raw foobar %}foo{% endraw %}');
-    }).to.throwError(/Unexpected token "foobar" in raw tag on line 1\./);
+  it('{% raw true %}{{ foo }}{% endraw %}', function () {
+    expect(swig.render('{% raw true %}{{ foo }}{% endraw %}'))
+      .to.equal('{{ foo }}');
+  });
+
+  it('{% raw false %}{{ foo }}{% endraw %}', function () {
+    expect(swig.render('{% raw false %}{{ foo }}{% endraw %}', {
+      locals: { foo: 'foobar' }
+    })).to.equal('foobar');
+  });
+
+  it('{% raw bool %}{{ foo }}{% endraw %}', function () {
+    expect(swig.render('{% raw true %}{{ foo }}{% endraw %}', {
+      locals: { bool: true }
+    })).to.equal('{{ foo }}');
+  });
+
+  it('{% raw bool %}{{ foo }}{% endraw %}', function () {
+    expect(swig.render('{% raw false %}{{ foo }}{% endraw %}', {
+      locals: { foo: 'foobar', bool: false }
+    })).to.equal('foobar');
   });
 });


### PR DESCRIPTION
This pull request does not break any use case with the raw tag instead it will parse a given argument when given as boolean and enable raw depending on that argument.

For example:

```
{% spaceless %}
<section>
{% raw %}<p>I like these brackets {{ }} yeah</p>{% endraw %}
{% raw client %}
<h3>{{ name }}</h3>
<!-- can be used by client -->
{% endraw %}
</section>
{% include './somefile.html' %}
{% endspaceless %}
```

This allows to have "server-prepared" templates compiled by browserify, component.io transforms. So you would not have to handle includes and spaceless on the client side.

Please review if everything is okay so far. Also you may have an idea how to remove code duplication on parser implementation of raw (is copied from the if tag).
