### PR TITLE
Fixes "include" tag compilation when parentFile is null

### DIFF
--- a/lib/tags/include.js
+++ b/lib/tags/include.js
@@ -32,7 +32,7 @@ exports.compile = function (compiler, args) {
   var file = args.shift(),
     onlyIdx = args.indexOf(only),
     onlyCtx = onlyIdx !== -1 ? args.splice(onlyIdx, 1) : false,
-    parentFile = args.pop().replace(/\\/g, '\\\\'),
+    parentFile = (args.pop() || '').replace(/\\/g, '\\\\'),
     ignore = args[args.length - 1] === missing ? (args.pop()) : false,
     w = args.join('');
 


### PR DESCRIPTION
I ran into "Uncaught TypeError: Cannot call method 'replace' of null " during browser client-side rendering.

**Javascript**

```
var html = swig.render(tmpl, {'locals': {
    'project': self.model.attributes
}});
```

**Template**

```
<div class="inner{% if project.is_loading %} loading{% endif %}">
    <div class="thumbnail">
        <a href="{{ project.absolute_url }}"><img alt="{{ project.name }}" src="{{ project.image_card_url }}"></a>
    </div>
    <h3 class="title"><a href="{{ project.absolute_url }}">{{ project.name }}</a></h3>
    <a class="desc">{{ project.description }}</a>
    <div class="actions">
        {% include "project/includes/project_button_activate.html" %}
    </div>
</div>
```
