### PR TITLE
Null should yield empty string when resolving variable

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -392,7 +392,7 @@ TokenParser.prototype = {
    * @private
    */
   checkMatch: function (match) {
-    var temp = match[0];
+    var temp = match[0], result;
 
     function checkDot(ctx) {
       var c = ctx + temp,
@@ -415,8 +415,8 @@ TokenParser.prototype = {
     function buildDot(ctx) {
       return '(' + checkDot(ctx) + ' ? ' + ctx + match.join('.') + ' : "")';
     }
-
-    return '(' + checkDot('_ctx.') + ' ? ' + buildDot('_ctx.') + ' : ' + buildDot('') + ')';
+    result = '(' + checkDot('_ctx.') + ' ? ' + buildDot('_ctx.') + ' : ' + buildDot('') + ')';
+    return '(' + result + ' !== null ? ' + result + ' : ' + '"" )';
   }
 };
 

--- a/tests/variables.test.js
+++ b/tests/variables.test.js
@@ -24,6 +24,10 @@ var cases = {
   'return empty string if undefined': [
     { c: '"{{ u }}"', e: '""' }
   ],
+  'return empty string if null': [
+    { c: '"{{ n }}"', e: '""' },
+    { c: '"{{ o3.n }}"', e: '""' }
+  ],
   'can use operators': [
     { c: '{{ a + 3 }}', e: '4' },
     { c: '{{ a * 3 }}', e: '3' },
@@ -88,8 +92,10 @@ describe('Variables', function () {
     g: { '0': { q: { c: { b: { foo: 'hi!' }}}}},
     h: { g: {  i: 'q' } },
     i: 'foo',
+    n: null,
     o: Object.create({ foo: function () { return 'bar'; } }),
-    o2: { a: 'bar', foo: function (b) { return b || this.a; } }
+    o2: { a: 'bar', foo: function (b) { return b || this.a; } },
+    o3: { n: null }
   }};
   _.each(cases, function (cases, description) {
     describe(description, function () {


### PR DESCRIPTION
This is related to #236. Am upvoting for showing empty string when resolving `null` object.

This is more similar to engines that swig is based on (Jinja/Django both resolves `None` as empty strings) and most of the time is more desired (I guess) than opaque `[Object object]`.

While writing tests was pretty straightforward, have to admit I am not sure about the implementation.

Let me know what you think.
