### PR TITLE
handle errors which occur at the time of rendering

### DIFF
--- a/lib/swig.js
+++ b/lib/swig.js
@@ -536,11 +536,21 @@ exports.Swig = function (opts) {
   this.renderFile = function (pathName, locals, cb) {
     if (cb) {
       self.compileFile(pathName, {}, function (err, fn) {
+        var result;
+
         if (err) {
           cb(err);
           return;
         }
-        cb(null, fn(locals));
+
+        try {
+          result = fn(locals);
+        } catch (err2) {
+          cb(err2);
+          return;
+        }
+
+        cb(null, result);
       });
       return;
     }

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -243,6 +243,16 @@ describe('swig.renderFile', function () {
       done();
     });
   });
+
+  it('can use callback with errors occurred at the time of rendering', function (done) {
+    var errorTest = __dirname + '/cases-error/error-thrown-from-function.test.html',
+      throwError = function () { throw new Error('error occurred on rendring'); };
+
+    swig.renderFile(errorTest, { throwError: throwError }, function (err, out) {
+      expect(err.message).to.equal('error occurred on rendring');
+      done();
+    });
+  });
 });
 
 describe('swig.run', function () {

--- a/tests/cases-error/error-thrown-from-function.test.html
+++ b/tests/cases-error/error-thrown-from-function.test.html
@@ -1,0 +1,3 @@
+<div>
+  {{ throwError() }}
+</div>


### PR DESCRIPTION
Erros could be thrown at the time of rendering instead of compiling when functions are called in templates. By this correction, the exception which occurs in renderFile at the time of rendering is passed to a callback.
