### PR TITLE
fs loader should take cwd as default base path

### DIFF
--- a/lib/loaders/filesystem.js
+++ b/lib/loaders/filesystem.js
@@ -29,7 +29,7 @@ module.exports = function (basepath, encoding) {
     if (basepath) {
       from = basepath;
     } else {
-      from = (from) ? path.dirname(from) : '/';
+      from = (from) ? path.dirname(from) : process.cwd();
     }
     return path.resolve(from, to);
   };

--- a/tests/loaders.test.js
+++ b/tests/loaders.test.js
@@ -105,6 +105,13 @@ describe('swig.loaders', function () {
         done();
       });
     });
+
+    it('takes cwd as default base path', function () {
+      var filepath = path.relative(process.cwd(), __dirname + '/cases/macros.html'),
+        s = new swig.Swig();
+
+      expect(s.renderFile(filepath)).to.equal(macroExpectation);
+    });
   });
 
 });


### PR DESCRIPTION
Let me know if there is something missing.
Also, I'm curious; shouldn't the memory loader have the same basepath by default? If yes, I can patch it as well.

Closes gh-418
