### PR TITLE
Make it ie8 compatible (sort of).

### DIFF
--- a/lib/swig.js
+++ b/lib/swig.js
@@ -590,7 +590,7 @@ exports.Swig = function (opts) {
     }
 
     context = getLocals(options);
-    contextLength = utils.keys(context).length; 
+    contextLength = utils.keys(context).length;
     pre = this.precompile(source, options);
 
     function compiled(locals) {


### PR DESCRIPTION
In modern js engine a array like [1,2,3,] will be intepreted as [1,2,3] 

But under IE8 it turns to [1,2,3,undefined]

I fix some little issue related with it. After this fix it's able to run under IE8 with some(many) other pollyfill. But those pollyfills can be done out side the swig.
