### PR TITLE
Allow filters to access local context

### DIFF
--- a/lib/swig.js
+++ b/lib/swig.js
@@ -604,6 +604,10 @@ exports.Swig = function (opts) {
       } else {
         lcls = {};
       }
+      
+      // Give filters access to local context
+      filters.context = lcls;
+      
       return pre.tpl(self, lcls, filters, utils, efn);
     }
 


### PR DESCRIPTION
Useful when you need to consume some local context data, from within filters.
Eg: 

``` javascript
context: {username: 'myuser'}

swig.setFilter('hello', function (input) {
    return '/' + this.context.username + '/';
});

```
