### PR TITLE
Removed excess code in lib.swig.setDefaults Issue #485

### DIFF
--- a/lib/swig.js
+++ b/lib/swig.js
@@ -142,12 +142,6 @@ function validateOptions(options) {
  */
 exports.setDefaults = function (options) {
   validateOptions(options);
-
-  var locals = utils.extend({}, defaultOptions.locals, options.locals || {});
-
-  utils.extend(defaultOptions, options);
-  defaultOptions.locals = locals;
-
   defaultInstance.options = utils.extend(defaultInstance.options, options);
 };
 


### PR DESCRIPTION
Discussed in Issue #485. Simple cleanup with passing tests. 
