### PR TITLE
functions are autoescaped unless .safe property explicitly set

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -191,6 +191,23 @@ exports.escape = function (input, type) {
 exports.e = exports.escape;
 
 /**
+ * Given a function return a function that is safely escaped. If the function
+ * passed in is already safe, then itself is returned.
+ *
+ * @param  {Function} fn
+ */
+exports.escFn = function (fn) {
+  if (fn.safe) {
+    return fn;
+  }
+  function inner() {
+    return exports.e(fn.apply(this, arguments));
+  }
+  inner.safe = true;
+  return inner;
+};
+
+/**
  * Get the first item in an array or character in a string. All other objects will attempt to return the first value available.
  *
  * @example

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -203,10 +203,11 @@ TokenParser.prototype = {
 
     case _t.FUNCTION:
     case _t.FUNCTIONEMPTY:
-      self.out.push('((typeof _ctx.' + match + ' !== "undefined") ? _ctx.' + match +
+      temp = self.escape ? '_filters.escFn' : '';
+      self.escape = false;
+      self.out.push(temp + '((typeof _ctx.' + match + ' !== "undefined") ? _ctx.' + match +
         ' : ((typeof ' + match + ' !== "undefined") ? ' + match +
         ' : _fn))(');
-      self.escape = false;
       if (token.type === _t.FUNCTIONEMPTY) {
         self.out[self.out.length - 1] = self.out[self.out.length - 1] + ')';
       } else {

--- a/tests/variables.test.js
+++ b/tests/variables.test.js
@@ -61,6 +61,10 @@ var cases = {
     { c: '{{ chalupa().bar() }}', e: 'chalupas' },
     { c: '{{ { foo: "bar" }.foo }}', e: 'bar' }
   ],
+  'escape functions by default': [
+    { c: '{{ orangeChicken() }}', e: '&lt;yum&gt;' },
+    { c: '{% autoescape false %}{{ orangeChicken() }}{% endautoescape %}', e: '<yum>' }
+  ],
   'can run multiple filters': [
     { c: '{{ a|default("")|default(1) }}', e: '1' }
   ],
@@ -99,7 +103,8 @@ describe('Variables', function () {
     n: null,
     o: Object.create({ foo: function () { return 'bar'; } }),
     o2: { a: 'bar', foo: function (b) { return b || this.a; }, $bar: 'bar' },
-    o3: { n: null }
+    o3: { n: null },
+    orangeChicken: function () { return "<yum>"; }
   }};
   _.each(cases, function (cases, description) {
     describe(description, function () {


### PR DESCRIPTION
TODO:
- [ ] - Handle the `|safe` filter correctly.
- [ ] - regression test for gh-297
