### PR TITLE
Make function output from locals autoescaped, keep macros safe

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -143,13 +143,18 @@ exports["default"] = function (input, def) {
  * @return {string}         Escaped string.
  */
 exports.escape = function (input, type) {
-  var out = iterateFilter.apply(exports.escape, arguments),
+  var isStringObject = utils.isStringObject(input),
+    out = !isStringObject ? iterateFilter.apply(exports.escape, arguments) : undefined,
     inp = input,
     i = 0,
     code;
 
   if (out !== undefined) {
     return out;
+  }
+
+  if (isStringObject && input.safe) {
+    return input.toString();
   }
 
   if (typeof input !== 'string') {
@@ -189,23 +194,6 @@ exports.escape = function (input, type) {
   }
 };
 exports.e = exports.escape;
-
-/**
- * Given a function return a function that is safely escaped. If the function
- * passed in is already safe, then itself is returned.
- *
- * @param  {Function} fn
- */
-exports.escFn = function (fn) {
-  if (fn.safe) {
-    return fn;
-  }
-  function inner() {
-    return exports.e(fn.apply(this, arguments));
-  }
-  inner.safe = true;
-  return inner;
-};
 
 /**
  * Get the first item in an array or character in a string. All other objects will attempt to return the first value available.

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -203,9 +203,7 @@ TokenParser.prototype = {
 
     case _t.FUNCTION:
     case _t.FUNCTIONEMPTY:
-      temp = self.escape ? '_filters.escFn' : '';
-      self.escape = false;
-      self.out.push(temp + '((typeof _ctx.' + match + ' !== "undefined") ? _ctx.' + match +
+      self.out.push('((typeof _ctx.' + match + ' !== "undefined") ? _ctx.' + match +
         ' : ((typeof ' + match + ' !== "undefined") ? ' + match +
         ' : _fn))(');
       if (token.type === _t.FUNCTIONEMPTY) {

--- a/lib/tags/macro.js
+++ b/lib/tags/macro.js
@@ -26,10 +26,11 @@ exports.compile = function (compiler, args, content, parents, options, blockName
     '    if (["' + args.join('","') + '"].indexOf(k) !== -1) { delete _ctx[k]; }\n' +
     '  });\n' +
     compiler(content, parents, options, blockName) + '\n' +
-    ' _ctx = _utils.extend(_ctx, __ctx);\n' +
+    '  _ctx = _utils.extend(_ctx, __ctx);\n' +
+    '  _output = new String(_output);\n' +
+    '  _output.safe = true;\n' +
     '  return _output;\n' +
-    '};\n' +
-    '_ctx.' + fnName + '.safe = true;\n';
+    '};\n';
 };
 
 exports.parse = function (str, line, parser, types) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -65,7 +65,16 @@ exports.each = function (obj, fn) {
  * @return {boolean}
  */
 exports.isArray = isArray = (Array.hasOwnProperty('isArray')) ? Array.isArray : function (obj) {
-  return (obj) ? (typeof obj === 'object' && Object.prototype.toString.call(obj).indexOf() !== -1) : false;
+  return (obj) ? (typeof obj === 'object' && Object.prototype.toString.call(obj).toLowerCase().indexOf('array') !== -1) : false;
+};
+
+/**
+ * Test if an object is a String.
+ * @param  {object}  obj
+ * @return {boolean}
+ */
+exports.isStringObject = function (obj) {
+  return (obj) ? (typeof obj === 'string' || (typeof obj === 'object' && Object.prototype.toString.call(obj).toLowerCase().indexOf('string') !== -1)) : false;
 };
 
 /**

--- a/tests/tags/macro.test.js
+++ b/tests/tags/macro.test.js
@@ -10,11 +10,11 @@ describe('Tag: macro', function () {
   });
 
   it('{% macro tacos(a, b, c) %}', function () {
-    expect(swig.render('{% macro tacos(a, b, c) %}{{ a }}, {{ c }}, {{ b }}{% endmacro %}{{ tacos(1, 3, 2) }}'))
-      .to.equal('1, 2, 3');
   });
 
   it('does not auto-escape', function () {
+    expect(swig.render('{% macro tacos(a, b, c) %}{{ a }}, {{ c }}, {{ b }}{% endmacro %}{{ tacos(1, 3, "<p>") }}'))
+      .to.equal('1, &lt;p&gt;, 3');
     expect(swig.render('{% macro foo %}<h1>{{ "<p>" }}</h1>{% endmacro %}{{ foo() }}'))
       .to.equal('<h1>&lt;p&gt;</h1>');
   });

--- a/tests/variables.test.js
+++ b/tests/variables.test.js
@@ -63,6 +63,7 @@ var cases = {
   ],
   'escape functions by default': [
     { c: '{{ orangeChicken() }}', e: '&lt;yum&gt;' },
+    { c: '{{ orangeChicken()|safe }}', e: '<yum>' },
     { c: '{% autoescape false %}{{ orangeChicken() }}{% endautoescape %}', e: '<yum>' }
   ],
   'can run multiple filters': [


### PR DESCRIPTION
Continuing work from @andrewrk from gh-494

Slightly alternative approach, albeit, potentially crazy... Uses a `String` object to mark the actual string itself as `safe`. When the `escape` filter hits a `String` object, it checks if the input is `safe`. If it is, just returns the string value and continues on.
