### PR TITLE
add a length filter that works for objects as well as arrays and strings

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -379,6 +379,7 @@ exports.length = function (input) {
   if (input.hasOwnProperty('length')) {
     return input.length;
   }
+  return '';
 };
 
 /**

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -156,7 +156,8 @@ var n = new Swig(),
     length: [
       { v: [1, 2, 3, 4], e: '4' },
       { v: '123', e: '3' },
-      { v: { foo: 'blah', bar: 'nope' }, e: '2'}
+      { v: { foo: 'blah', bar: 'nope' }, e: '2'},
+      { v: 5, e: ''}
     ],
     lower: [
       { v: 'BaR', e: 'bar' },


### PR DESCRIPTION
A minor convenience, but still nice to have.

There was some previous discussion that indicated that such a thing would be a welcome addition (https://github.com/paularmstrong/swig/pull/335) but that looks to have stalled a while ago.
