### PR TITLE
Fixes import example typo

### DIFF
--- a/lib/tags/import.js
+++ b/lib/tags/import.js
@@ -7,7 +7,7 @@ var utils = require('../utils');
  * @alias import
  *
  * @example
- * {% import './formmacros.html' as forms %}
+ * {% import './formmacros.html' as form %}
  * {{ form.input("text", "name") }}
  * // => <input type="text" name="name">
  *


### PR DESCRIPTION
Changes 'forms' to 'form' in the example snippet.
