### PR TITLE
Adds support for CSP-strict environments like node-webkit and atom-shell

### DIFF
--- a/lib/swig.js
+++ b/lib/swig.js
@@ -499,8 +499,8 @@ exports.Swig = function (opts) {
     }
 
     try {
-      if (this.options.safeMode) {
-        tpl = new this.SafeFunction('_swig', '_ctx', '_filters', '_utils', '_fn',
+      if (self.options && self.options.safeMode) {
+        tpl = new self.SafeFunction('_swig', '_ctx', '_filters', '_utils', '_fn',
           '  var _ext = _swig.extensions,\n' +
           '    _output = "";\n' +
           parser.compile(tokens, parents, options) + '\n' +

--- a/lib/swig.js
+++ b/lib/swig.js
@@ -3,7 +3,8 @@ var utils = require('./utils'),
   _filters = require('./filters'),
   parser = require('./parser'),
   dateformatter = require('./dateformatter'),
-  loaders = require('./loaders');
+  loaders = require('./loaders'),
+  vm = require('vm');
 
 /**
  * Swig version number as a string.
@@ -18,7 +19,7 @@ exports.version = "1.4.2";
  * Swig Options Object. This object can be passed to many of the API-level Swig methods to control various aspects of the engine. All keys are optional.
  * @typedef {Object} SwigOpts
  * @property {boolean} autoescape  Controls whether or not variable output will automatically be escaped for safe HTML output. Defaults to <code data-language="js">true</code>. Functions executed in variable statements will not be auto-escaped. Your application/functions should take care of their own auto-escaping.
- * @property {boolean} safeMode  Controls whether or not to run swig in a mode that uses a Function override via loophole (https://github.com/atom/loophole) to compile templates (especially useful for running in environments with strict CSP like atom-shell or node-webkit) 
+ * @property {boolean} runInVm  Controls whether or not to compile templates in a vm context (especially useful for running in environments with strict CSP like atom-shell or node-webkit) 
  * @property {array}   varControls Open and close controls for variables. Defaults to <code data-language="js">['{{', '}}']</code>.
  * @property {array}   tagControls Open and close controls for tags. Defaults to <code data-language="js">['{%', '%}']</code>.
  * @property {array}   cmtControls Open and close controls for comments. Defaults to <code data-language="js">['{#', '#}']</code>.
@@ -28,7 +29,7 @@ exports.version = "1.4.2";
  */
 var defaultOptions = {
     autoescape: true,
-    safeMode: false,
+    runInVm: false,
     varControls: ['{{', '}}'],
     tagControls: ['{%', '%}'],
     cmtControls: ['{#', '#}'],
@@ -175,8 +176,6 @@ exports.Swig = function (opts) {
   this.options = utils.extend({}, defaultOptions, opts || {});
   this.cache = {};
   this.extensions = {};
-  this.SafeFunction = require('loophole').Function;
-  this.SafeFunction.prototype.call = global.Function.prototype.call;
   var self = this,
     tags = _tags,
     filters = _filters;
@@ -330,6 +329,27 @@ exports.Swig = function (opts) {
   this.setExtension = function (name, object) {
     self.extensions[name] = object;
   };
+
+  /**
+   * Function override for node environments with strict CSP (node-webkit and atom-shell)
+   */
+  this.SafeFunction = function() {
+    var __slice = [].slice;
+    var body, paramList, paramLists, params, _i, _j, _len;
+    paramLists = 2 <= arguments.length ? __slice.call(arguments, 0, _i = arguments.length - 1) : (_i = 0, []), body = arguments[_i++];
+    params = [];
+    for (_j = 0, _len = paramLists.length; _j < _len; _j++) {
+      paramList = paramLists[_j];
+      if (typeof paramList === 'string') {
+        paramList = paramList.split(/\s*,\s*/);
+      }
+      params.push.apply(params, paramList);
+    }
+    return vm.runInThisContext("(function(" + (params.join(', ')) + ") {\n  " + body + "\n})");
+  };
+
+  this.SafeFunction.prototype.call = global.Function.prototype.call;
+
 
   /**
    * Parse a given source string into tokens.
@@ -499,7 +519,7 @@ exports.Swig = function (opts) {
     }
 
     try {
-      if (self.options && self.options.safeMode) {
+      if (self.options && self.options.runInVm) {
         tpl = new self.SafeFunction('_swig', '_ctx', '_filters', '_utils', '_fn',
           '  var _ext = _swig.extensions,\n' +
           '    _output = "";\n' +

--- a/lib/swig.js
+++ b/lib/swig.js
@@ -333,12 +333,18 @@ exports.Swig = function (opts) {
   /**
    * Function override for node environments with strict CSP (node-webkit and atom-shell)
    */
-  this.SafeFunction = function() {
-    var __slice = [].slice;
-    var body, paramList, paramLists, params, _i, _j, _len;
-    paramLists = 2 <= arguments.length ? __slice.call(arguments, 0, _i = arguments.length - 1) : (_i = 0, []), body = arguments[_i++];
+  this.SafeFunction = function () {
+    var __slice, body, paramList, paramLists, params, _i, _j, _len;
+    __slice = [].slice;
+    if (2 <= arguments.length) {
+      paramLists = __slice.call(arguments, 0, _i = arguments.length - 1);
+    } else {
+      _i = 0;
+      paramLists = [];
+    }
+    body = arguments[_i];
     params = [];
-    for (_j = 0, _len = paramLists.length; _j < _len; _j++) {
+    for (_j = 0, _len = paramLists.length; _j < _len; _j += 1) {
       paramList = paramLists[_j];
       if (typeof paramList === 'string') {
         paramList = paramList.split(/\s*,\s*/);

--- a/lib/swig.js
+++ b/lib/swig.js
@@ -18,6 +18,7 @@ exports.version = "1.4.2";
  * Swig Options Object. This object can be passed to many of the API-level Swig methods to control various aspects of the engine. All keys are optional.
  * @typedef {Object} SwigOpts
  * @property {boolean} autoescape  Controls whether or not variable output will automatically be escaped for safe HTML output. Defaults to <code data-language="js">true</code>. Functions executed in variable statements will not be auto-escaped. Your application/functions should take care of their own auto-escaping.
+ * @property {boolean} safeMode  Controls whether or not to run swig in a mode that uses a Function override via loophole (https://github.com/atom/loophole) to compile templates (especially useful for running in environments with strict CSP like atom-shell or node-webkit) 
  * @property {array}   varControls Open and close controls for variables. Defaults to <code data-language="js">['{{', '}}']</code>.
  * @property {array}   tagControls Open and close controls for tags. Defaults to <code data-language="js">['{%', '%}']</code>.
  * @property {array}   cmtControls Open and close controls for comments. Defaults to <code data-language="js">['{#', '#}']</code>.
@@ -27,6 +28,7 @@ exports.version = "1.4.2";
  */
 var defaultOptions = {
     autoescape: true,
+    safeMode: false,
     varControls: ['{{', '}}'],
     tagControls: ['{%', '%}'],
     cmtControls: ['{#', '#}'],
@@ -173,6 +175,8 @@ exports.Swig = function (opts) {
   this.options = utils.extend({}, defaultOptions, opts || {});
   this.cache = {};
   this.extensions = {};
+  this.SafeFunction = require('loophole').Function;
+  this.SafeFunction.prototype.call = global.Function.prototype.call;
   var self = this,
     tags = _tags,
     filters = _filters;
@@ -495,12 +499,21 @@ exports.Swig = function (opts) {
     }
 
     try {
-      tpl = new Function('_swig', '_ctx', '_filters', '_utils', '_fn',
-        '  var _ext = _swig.extensions,\n' +
-        '    _output = "";\n' +
-        parser.compile(tokens, parents, options) + '\n' +
-        '  return _output;\n'
-        );
+      if (this.options.safeMode) {
+        tpl = new this.SafeFunction('_swig', '_ctx', '_filters', '_utils', '_fn',
+          '  var _ext = _swig.extensions,\n' +
+          '    _output = "";\n' +
+          parser.compile(tokens, parents, options) + '\n' +
+          '  return _output;\n'
+          );
+      } else {
+        tpl = new Function('_swig', '_ctx', '_filters', '_utils', '_fn',
+          '  var _ext = _swig.extensions,\n' +
+          '    _output = "";\n' +
+          parser.compile(tokens, parents, options) + '\n' +
+          '  return _output;\n'
+          );
+      }
     } catch (e) {
       utils.throwError(e, null, options.filename);
     }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "author": "Paul Armstrong <paul@paularmstrongdesigns.com>",
   "dependencies": {
     "uglify-js": "~2.4",
-    "optimist": "~0.6"
+    "optimist": "~0.6",
+    "loophole":"1.0.0"
   },
   "devDependencies": {
     "lodash": "~1.3.1",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   "author": "Paul Armstrong <paul@paularmstrongdesigns.com>",
   "dependencies": {
     "uglify-js": "~2.4",
-    "optimist": "~0.6",
-    "loophole":"1.0.0"
+    "optimist": "~0.6"
   },
   "devDependencies": {
     "lodash": "~1.3.1",

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -115,6 +115,16 @@ describe('options', function () {
     });
   });
 
+  describe('safeMode', function () {
+    it('can be set as default', function () {
+      swig.setDefaults({ safeMode: true, locals: { a: 1, b: 2 }});
+      var tpl = '{{ a }}{{ b }}{{ c }}';
+      expect(swig.compile(tpl)({ c: 3 })).to.equal('123');
+      expect(swig.compile(tpl, { locals: { c: 3 }})()).to.equal('123');
+      expect(swig.render(tpl, { locals: { c: 3 }})).to.equal('123');
+    });
+  });
+
   describe('cache', function () {
     it('can be falsy', function () {
       var s = new Swig({ cache: false });

--- a/tests/basic.test.js
+++ b/tests/basic.test.js
@@ -115,9 +115,9 @@ describe('options', function () {
     });
   });
 
-  describe('safeMode', function () {
+  describe('runInVm', function () {
     it('can be set as default', function () {
-      swig.setDefaults({ safeMode: true, locals: { a: 1, b: 2 }});
+      swig.setDefaults({ runInVm: true, locals: { a: 1, b: 2 }});
       var tpl = '{{ a }}{{ b }}{{ c }}';
       expect(swig.compile(tpl)({ c: 3 })).to.equal('123');
       expect(swig.compile(tpl, { locals: { c: 3 }})()).to.equal('123');


### PR DESCRIPTION
I'm writing a rather complicated package for the Atom editor and I require templating functionality. In order to avoid running my server/templating in a node subprocess, I've added a `safeMode` flag to swig which prompts swig to use [`loophole`](https://github.com/atom/loophole) to run the compilation in a vm context. This allows my Atom package to be installed/run normally. Without this functionality swig cannot be used as a dependency in environments like `node-webkit` or `atom-shell` that have (rightfully so) strict content security policies.

Thanks in advance for your consideration.

-Joe
