### PR TITLE
Cloning of filters for new instances

### DIFF
--- a/lib/swig.js
+++ b/lib/swig.js
@@ -174,8 +174,8 @@ exports.Swig = function (opts) {
   this.cache = {};
   this.extensions = {};
   var self = this,
-    tags = _tags,
-    filters = _filters;
+    tags = utils.extend({}, _tags),
+    filters = utils.extend({}, _filters);
 
   /**
    * Get combined locals context.

--- a/lib/tags/filter.js
+++ b/lib/tags/filter.js
@@ -1,4 +1,3 @@
-var filters = require('../filters');
 
 /**
  * Apply a filter to an entire block of template.
@@ -36,7 +35,7 @@ exports.parse = function (str, line, parser, types) {
   var filter;
 
   function check(filter) {
-    if (!filters.hasOwnProperty(filter)) {
+    if (!parser.filters.hasOwnProperty(filter)) {
       throw new Error('Filter "' + filter + '" does not exist on line ' + line + '.');
     }
   }

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -332,7 +332,9 @@ describe('Filters:', function () {
 		s2.setFilter('foo', function () { return 'foo2'; });
 
 		expect(s1.render('{{ ""|foo }}')).to.equal('foo1');
+    expect(s1.compile('{{ ""|foo }}')({})).to.equal('foo1');
 		expect(s2.render('{{ ""|foo }}')).to.equal('foo2');
+    expect(s2.compile('{{ ""|foo }}')({})).to.equal('foo2');
 	});
 
 });

--- a/tests/filters.test.js
+++ b/tests/filters.test.js
@@ -323,4 +323,16 @@ describe('Filters:', function () {
     expect(swig.render('{% if "0+3+1" === getFoo("f")|join("+")|reverse && null|default(true) %}yep{% endif %}', { locals: locals })).to.equal('yep');
   });
 
+	it("gh-547: Filters with same name in different instances", function () {
+
+		var s1 = new Swig(),
+			s2 = new Swig();
+
+		s1.setFilter('foo', function () { return 'foo1'; });
+		s2.setFilter('foo', function () { return 'foo2'; });
+
+		expect(s1.render('{{ ""|foo }}')).to.equal('foo1');
+		expect(s2.render('{{ ""|foo }}')).to.equal('foo2');
+	});
+
 });

--- a/tests/tags/filter.test.js
+++ b/tests/tags/filter.test.js
@@ -26,4 +26,17 @@ describe('Tag: filter', function () {
       swig.render('{% filter foobar %}{% endfilter %}');
     }).to.throwError(/Filter \"foobar\" does not exist on line 1\./);
   });
+
+  it("gh-547: Filters with same name in different instances", function () {
+
+    var s1 = new Swig(),
+      s2 = new Swig();
+
+    s1.setFilter('foo', function () { return 'foo1'; });
+    s2.setFilter('foo', function () { return 'foo2'; });
+
+    expect(s1.render('{% filter foo %}{% endfilter %}')).to.equal('foo1');
+    expect(s2.render('{% filter foo %}{% endfilter %}')).to.equal('foo2');
+  });
+
 });

--- a/tests/tags/filter.test.js
+++ b/tests/tags/filter.test.js
@@ -36,7 +36,9 @@ describe('Tag: filter', function () {
     s2.setFilter('foo', function () { return 'foo2'; });
 
     expect(s1.render('{% filter foo %}{% endfilter %}')).to.equal('foo1');
+    expect(s1.compile('{% filter foo %}{% endfilter %}')({})).to.equal('foo1');
     expect(s2.render('{% filter foo %}{% endfilter %}')).to.equal('foo2');
+    expect(s2.compile('{% filter foo %}{% endfilter %}')({})).to.equal('foo2');
   });
 
 });


### PR DESCRIPTION
Cloning of filters and tags when creating new swig instances to prevent filters and tags to be shared
