### PR TITLE
Allow Carriage Returns

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -435,7 +435,9 @@ TokenParser.prototype = {
  * @return {array}          List of tokens ready for compilation.
  */
 exports.parse = function (swig, source, opts, tags, filters) {
-  source = source.replace(/\r\n/g, '\n');
+  if (!opts.allowCR) {
+    source = source.replace(/\r\n/g, '\n');
+  }
   var escape = opts.autoescape,
     tagOpen = opts.tagControls[0],
     tagClose = opts.tagControls[1],
@@ -708,12 +710,13 @@ exports.parse = function (swig, source, opts, tags, filters) {
  */
 exports.compile = function (template, parents, options, blockName) {
   var out = '',
-    tokens = utils.isArray(template) ? template : template.tokens;
+    tokens = utils.isArray(template) ? template : template.tokens,
+    escapedLineEndingsFn = options.allowCR ? escapeLineEndingsAllowCR : escapeLineEndings;
 
   utils.each(tokens, function (token) {
     var o;
     if (typeof token === 'string') {
-      out += '_output += "' + token.replace(/\\/g, '\\\\').replace(/\n|\r/g, '\\n').replace(/"/g, '\\"') + '";\n';
+      out += '_output += "' + escapedLineEndingsFn(token.replace(/\\/g, '\\\\')).replace(/"/g, '\\"') + '";\n';
       return;
     }
 
@@ -742,3 +745,12 @@ exports.compile = function (template, parents, options, blockName) {
 
   return out;
 };
+
+function escapeLineEndings(str) {
+  return str.replace(/\n|\r/g, '\\n');
+}
+
+function escapeLineEndingsAllowCR(str) {
+  // Escape CR + LF and then escape individual CR or LF characters.
+  return str.replace(/\r\n/g, '\\r\\n').replace(/[^\r]\n|\r[^\n]/g, '\\n');
+}

--- a/lib/swig.js
+++ b/lib/swig.js
@@ -551,7 +551,7 @@ exports.Swig = function (opts) {
    */
   this.renderFile = function (pathName, locals, cb) {
     if (cb) {
-      self.compileFile(pathName, {}, function (err, fn) {
+      self.compileFile(pathName, self.options, function (err, fn) {
         var result;
 
         if (err) {
@@ -571,7 +571,7 @@ exports.Swig = function (opts) {
       return;
     }
 
-    return self.compileFile(pathName)(locals);
+    return self.compileFile(pathName, self.options)(locals);
   };
 
   /**

--- a/lib/swig.js
+++ b/lib/swig.js
@@ -68,7 +68,11 @@ var defaultOptions = {
      *   page1: '{% extends "layout" %}{% block foo %}Tacos!{% endblock %}'
      * })});
      */
-    loader: loaders.fs()
+    loader: loaders.fs(),
+    /**
+     * Configure Swig to allow carriage return characters in templates. Default is false.
+     */
+    allowCR: false
   },
   defaultInstance;
 


### PR DESCRIPTION
For issue #540 - these changes preserve the CR characters in templates so that they can appear in the generated output.

I have not created any tests for this other than confirming that it works in the only program that I currently use swig in ([hashids-tsql](https://github.com/waynebloss/hashids-tsql/)). If I have time to make some tests in the future, I will ~ but, perhaps @paularmstrong, you could take a look at these 2 commits and enlighten me as to why I needed the 2nd commit to make this work. Am I doing something wrong? Thanks!