### PR TITLE
Fix `this` in swig.compile()

### DIFF
--- a/lib/swig.js
+++ b/lib/swig.js
@@ -603,7 +603,7 @@ exports.Swig = function (opts) {
 
     context = getLocals(options);
     contextLength = utils.keys(context).length;
-    pre = this.precompile(source, options);
+    pre = self.precompile(source, options);
 
     function compiled(locals) {
       var lcls;


### PR DESCRIPTION
The value of `this` might be modified when called in other situations.

All other references to `this` are guarded with `self` in all other functions.

In particular, this should fix Travis errors in jstransformers/jstransformer-swig#2: https://travis-ci.org/jstransformers/jstransformer-swig/builds/51301563
