### PR TITLE
Make swig more comply with express and add {% attach %} tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ tests/browser.js
 tmp
 docs/docs/*.json
 docs/coverage.html
+.idea

--- a/lib/swig.js
+++ b/lib/swig.js
@@ -734,7 +734,7 @@ exports.precompile = defaultInstance.precompile;
 exports.compile = defaultInstance.compile;
 exports.compileFile = defaultInstance.compileFile;
 exports.render = defaultInstance.render;
-exports.renderFile = defaultInstance.renderFile;
+exports.__express = exports.renderFile = defaultInstance.renderFile;
 exports.run = defaultInstance.run;
 exports.invalidateCache = defaultInstance.invalidateCache;
 exports.loaders = loaders;

--- a/lib/tags/attach.js
+++ b/lib/tags/attach.js
@@ -1,23 +1,20 @@
 var ignore = 'ignore',
     missing = 'missing';
-/*
-var path = require('path'),
-    resolve = path.resolve,
-    dirname = path.dirname;
-
-exports.compile = function (compiler, args, content, parents, options, blockName) {
-  var file = args.shift().replace(/'/g, ''),
-      parentFile = (args.pop() || '').replace(/\\/g, '\\\\'),
-      ignore = args[args.length - 1] === missing ? (args.pop()) : false;
 
 
-
-
-  file = resolve(dirname(parentFile), file);
-  return (ignore ? ' try {\n' : '') +
-    '_output += _swig.options.loader.load(\'' + file + '\');\n' +
-    (ignore ? '} catch (e) {}\n' : '');
-};*/
+/**
+ * Attach a file in place. Forces the content to not be auto-escaped. All swig instructions will be ignored and the content will be rendered exactly as it was given.
+ *
+ *
+ * @example
+ * // var foobar = '<p>'
+ * // {{ foobar }}
+ * {% attach './foobar.txt' %}
+ * // => {{ foobar }}
+ *
+ * @param {string|var}  file      The path, relative to the template root, to render into the current context.
+ * @param {literal}     [ignore missing] Will output empty string if not found instead of throwing an error.
+ */
 
 exports.compile = function (compiler, args, content, parents, options, blockName) {
   var file = args.shift(),

--- a/lib/tags/attach.js
+++ b/lib/tags/attach.js
@@ -1,0 +1,75 @@
+var ignore = 'ignore',
+    missing = 'missing';
+/*
+var path = require('path'),
+    resolve = path.resolve,
+    dirname = path.dirname;
+
+exports.compile = function (compiler, args, content, parents, options, blockName) {
+  var file = args.shift().replace(/'/g, ''),
+      parentFile = (args.pop() || '').replace(/\\/g, '\\\\'),
+      ignore = args[args.length - 1] === missing ? (args.pop()) : false;
+
+
+
+
+  file = resolve(dirname(parentFile), file);
+  return (ignore ? ' try {\n' : '') +
+    '_output += _swig.options.loader.load(\'' + file + '\');\n' +
+    (ignore ? '} catch (e) {}\n' : '');
+};*/
+
+exports.compile = function (compiler, args, content, parents, options, blockName) {
+  var file = args.shift(),
+    parentFile = (args.pop() || '').replace(/\\/g, '\\\\'),
+    ignore = args[args.length - 1] === missing ? (args.pop()) : false;
+
+  return (ignore ? ' try {\n' : '') +
+    '_output += _swig.options.loader.load(_swig.options.loader.resolve(' + file + ', "' + parentFile + '"));\n' +
+    (ignore ? '} catch (e) {}\n' : '');
+};
+
+
+exports.parse = function (str, line, parser, types, stack, opts) {
+  var file;
+  parser.on(types.STRING, function (token) {
+    if (!file) {
+      file = token.match;
+      this.out.push(file);
+      return;
+    }
+
+    return true;
+  });
+
+  parser.on(types.VAR, function (token) {
+    if (!file) {
+      file = token.match;
+      return true;
+    }
+
+    if (token.match === ignore) {
+      return false;
+    }
+
+    if (token.match === missing) {
+      if (this.prevToken.match !== ignore) {
+        throw new Error('Unexpected token "' + missing + '" on line ' + line + '.');
+      }
+      this.out.push(token.match);
+      return false;
+    }
+
+    if (this.prevToken.match === ignore) {
+      throw new Error('Expected "' + missing + '" on line ' + line + ' but found "' + token.match + '".');
+    }
+
+    return true;
+  });
+
+  parser.on('end', function () {
+    this.out.push(opts.filename || null);
+  });
+
+  return true;
+};

--- a/lib/tags/index.js
+++ b/lib/tags/index.js
@@ -14,3 +14,4 @@ exports.parent = require('./parent');
 exports.raw = require('./raw');
 exports.set = require('./set');
 exports.spaceless = require('./spaceless');
+exports.attach = require('./attach');


### PR DESCRIPTION
Hi, not sure if any rule to make pull request, apologized if I am wrong.

1. In express, if require('swig').__express exist, you don't need to use `app.engine('html', swig.renderFile)`. You can simply make your template file extension name as `.swig`，
   and `app.set('view engine', 'swig')`, express will be very smart to require('swig') for you to render the swig template, just like jade. It is also very helpful to distinguish a template from a html file in server side. I believe a template which should be a file which need to be rendered in server-side. A html file is something should be exactly what it is when it comes to browser side.

2. {% attach %} tag ( Or change its name to {% rawfile %}, which is the best way to include template files for client-side rendering. For example, you might need to render swig template in the browser, {% attach 'box.swig' %} will include the box.swig file in place. and just put it in the place like {% raw %}{% end raw %} I've used it for some Ractive.js or other client side component coding, because it would be better to attach the templates in server-rendering instead of loading them via Internet. I believe swig is the best server-side rendering now and future, but we might need to consider to allow some client-side template or components could be rendered in server-side, e.g. react.js, Angular's mustache, Handlebars, Ractive.js