### PR TITLE
change checking Error.errno to Error.code

### DIFF
--- a/bin/swig.js
+++ b/bin/swig.js
@@ -93,7 +93,7 @@ if (argv.o !== 'stdout') {
   try {
     fs.mkdirSync(argv.o);
   } catch (e) {
-    if (e.code !== "EEXIST") {
+    if (e.code !== 'EEXIST') {
       throw e;
     }
   }

--- a/bin/swig.js
+++ b/bin/swig.js
@@ -93,7 +93,7 @@ if (argv.o !== 'stdout') {
   try {
     fs.mkdirSync(argv.o);
   } catch (e) {
-    if (e.errno !== 47) {
+    if (e.code !== "EEXIST") {
       throw e;
     }
   }


### PR DESCRIPTION
Update the check for existing output directory to use `.code` instead of `.errno`.

`.errno` is a deprecated property as explained here : https://github.com/joyent/node/issues/2211#issuecomment-2896181.

And on iojs 1.5.x and node 0.12.x on OSX libuv returns the `errno` value of -17 for **EEXISTS** hence causing this piece of code to throw the an error if the output directory exists.
