### PR TITLE
Fix tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "author": "Paul Armstrong <paul@paularmstrongdesigns.com>",
   "dependencies": {
-    "uglify-js": "~2.4",
+    "uglify-js": "2.4.24",
     "optimist": "~0.6"
   },
   "devDependencies": {

--- a/tests/bin/bin.test.js
+++ b/tests/bin/bin.test.js
@@ -89,7 +89,7 @@ describe('bin/swig compile -m', function () {
   it('minifies output', function (done) {
     var p = fixPath(casedir + '/extends_1.test.html');
     exec('node ' + bin + ' compile ' + p + ' -m', function (err, stdout, stderr) {
-      expect(stdout).to.equal('var tpl=function(n){var e=(n.extensions,"");return e+="Hi,\\n\\n",e+="This is the body.",e+="\\n\\nSincerely,\\nMe\\n"};\n');
+      expect(stdout).to.equal('var tpl=function(n,e,i,r,t){var s=(n.extensions,"");return s+="Hi,\\n\\n",s+="This is the body.",s+="\\n\\nSincerely,\\nMe\\n"};\n');
       done();
     });
   });


### PR DESCRIPTION
The [semantic version usage for the uglify dependency](https://github.com/paularmstrong/swig/blob/9a69b0c66763d946161277dba38221e6855387cb/package.json#L21) has led to [tests breaking on the `bin/swig compile -m minifies output` assertion](https://travis-ci.org/paularmstrong/swig/builds/68384015#L872).

[Older versions of 2.4 work here](https://travis-ci.org/paularmstrong/swig/builds/46826693#L125) but [newer versions of 2.4 do not](https://travis-ci.org/paularmstrong/swig/builds/68384015#L115), causing this problem to have arisen over time.

The approach used here was to simply specify the version of uglify to be the latest, and to update that assertion to mirror uglify output.  Alternatively, you could use an npm shrinkwrap file if you don't like changing the version in package.json.
