### PR TITLE
Fixed error caused in node.js 4.*

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -690,7 +690,7 @@ exports.parse = function (swig, source, opts, tags, filters) {
   });
 
   return {
-    name: opts.filename,
+    filename: opts.filename,
     parent: parent,
     tokens: tokens,
     blocks: blocks


### PR DESCRIPTION
Fixed: TypeError: Cannot assign to read only property 'name' of function compiled(locals)
with node option --use-strict

https://github.com/paularmstrong/swig/issues/523
