### PR TITLE
Update uglify-js to 2.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "author": "Paul Armstrong <paul@paularmstrongdesigns.com>",
   "dependencies": {
-    "uglify-js": "~2.4",
+    "uglify-js": "~2.6",
     "optimist": "~0.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Fix https://github.com/paularmstrong/swig/issues/648 

uglify-js 2.4.x is vulnerable to regular expression denial of service (ReDoS) when certain types of input is passed into .parse().
