### PR TITLE
Changed throwError to not append a dot.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -180,5 +180,5 @@ exports.throwError = function (message, line, file) {
   if (file) {
     message += ' in file ' + file;
   }
-  throw new Error(message + '.');
+  throw new Error(message);
 };


### PR DESCRIPTION
So... I was working on something and using swig and got the following error when trying to render a template.

``` bash
Error: SyntaxError: Unexpected token !==.
```

I was going crazy searching for '!==.' thinking I had a syntax error and then even looked into swig. I think adding the dot, especially when an unexpected token is the error is quite misleading & not helpful.

The error btw, if you are interested in handling it more specifically is that I had a `{{ foo. bar}}` (notice the space).

Thoughts?
